### PR TITLE
Use site.name, not site.title per _config.yml

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -13,7 +13,7 @@ json: false
 	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
 	>
 <channel>
-    <title xml:lang="en">{{ site.title}}</title>
+    <title xml:lang="en">{{ site.name }}</title>
     <atom:link type="application/atom+xml" href="{{ site.url }}/feed/" rel="self"/>
     <link>{{ site.url }}</link>
     <pubDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>


### PR DESCRIPTION
Without this, the title of the feed is empty, which looks goofy for rss readers.
