### PR TITLE
Add default rake task, add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ assets/vendor/modernizr/feature-detects
 assets/vendor/modernizr/media
 assets/vendor/modernizr/test
 .bundle
+.idea

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,5 @@ task :test do
   Rake::Task["assets:precompile"].execute
   HTML::Proofer.new("./_site", :href_ignore => ["#comments"]).run
 end
+
+task :default => :test


### PR DESCRIPTION
Add a default rake task to Rakefile (The test task). This should fix errors when building with [Travis](http://travis-ci.org), such as `/home/travis/build/benbalter/benbalter.github.com/Rakefile:11:in `block in <top (required)>'
Tasks: TOP => test`

Add .idea to the .gitignore file, to allow [JetBrains WebStorm](http://www.jetbrains.com/webstorm) and [JetBrains RubyMine](http://www.jetbrains.com/ruby) users to commit without having to delete
build files.
