### PR TITLE
Disable jekyll-mentions and fix CSS for nav.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -131,6 +131,6 @@ encoding: UTF-8
 
 gems:
   - jemoji
-  - jekyll-mentions
+  #- jekyll-mentions
   - jekyll-redirect-from
   - jekyll-sitemap

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -81,10 +81,9 @@ body { padding-top: 20px; font-size: 1.6em; font-weight: 200; }
 .navbar h2 { font-weight: normal; font-size: 20px; display: inline;}
 .navbar-brand { font-size: 20px; }
 @media (max-width: 768px) {
-    .navbar .pull-right, .navbar-brand { text-align: center; float: none; width: 100%; }
-}
-@media (max-width: 768px) {
-    .navbar li { text-align: center;}
+  .navbar .pull-right, .navbar-brand { text-align: center; float: none; width: 100%; }
+  .navbar li { text-align: center; }
+  .navbar-nav { margin: 0; }
 }
 @media (max-width: 1200px) {
   .nav { font-size: 0.9em; }


### PR DESCRIPTION
Fixes #122. Re-enable when jekyll-mentions 0.0.7 or 0.1.1 is put onto GitHub Pages.

Check it out live: http://benbalter.parkermoo.re

/cc @benbalter 
