### PR TITLE
Ignore the vendor/ folder so Travis doesn't flip out

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,7 @@ exclude:
   - assets/vendor/modernizr/media
   - assets/vendor/modernizr/test
   - ".bundle"
+  - vendor
 
 #number of items in RSS feed
 rss_limit: 10


### PR DESCRIPTION
In future versions of Jekyll, this file will not be installed with the gem. But for now, it's still a nuisance.
