### PR TITLE
remove whitespace before the xml declaration to make rss valid

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -3,12 +3,12 @@ layout: none
 permalink: /feed/
 json: false
 ---
+<?xml version="1.0" encoding="utf-8"?>
 {% if site.github.url %}
 	{% assign url_base = site.github.url %}
 {% else %}
 	{% assign url_base = site.url %}
 {% endif %}
-<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0"
 	xmlns:content="http://purl.org/rss/1.0/modules/content/"
 	xmlns:wfw="http://wellformedweb.org/CommentAPI/"


### PR DESCRIPTION
Tiny tweak to make rss pass validation, it currently has an xml issue:
- http://feedvalidator.org/check.cgi?url=http%3A%2F%2Fben.balter.com%2Ffeed%2F
- http://feedvalidator.org/docs/error/SAXError.html

> Another common error is the inclusion of whitespace characters (spaces, tabs, newlines) before the XML Declaration. If an XML Declaration is included, it must be the first thing in the document

Most RSS readers don't seem to care, but mine (liferea) randomly does, so hope you can take the tweak. Thanks!
