### PR TITLE
Point to html-proofer gem's master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 #github
 gem 'github-pages'
 gem 'rake'
-gem 'html-proofer', :github => "gjtorikian/html-proofer", :branch => "utf-8-urls"
+gem 'html-proofer'


### PR DESCRIPTION
utf-8-urls has been merged into master
https://github.com/gjtorikian/html-proofer/pull/137