### PR TITLE
Redirect to the `fine-print/` directory

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
 	{% else %}
 	<div class="col-sm-10 col-sm-offset-1 footer">
 	{% endif %}
-		<div class="fine-print"><a href="{{ url_base }}/fine-print">Fine Print</a></div>
+		<div class="fine-print"><a href="{{ url_base }}/fine-print/">Fine Print</a></div>
 	</div>
 </div>
 


### PR DESCRIPTION
Rather than relying on Nginx to realize it's a dir, go to the dir directly. The response from the service in the previous iteration would be 301 Permanently Moved, which isn't so great. It generates a second request every time someone clicks this link. :frowning:

Noticed this in the test output for https://github.com/benbalter/benbalter.github.com/pull/211

So great catching up with you tonight!! :beers: 