### PR TITLE
Smartify

### DIFF
--- a/_includes/smartify
+++ b/_includes/smartify
@@ -1,1 +1,1 @@
-{{ include.text | mardownify | strip_html }}
+{{ include.text | markdownify | strip_html }}

--- a/_includes/smartify
+++ b/_includes/smartify
@@ -1,0 +1,1 @@
+{{ include.text | mardownify | strip_html }}

--- a/_includes/smartify.html
+++ b/_includes/smartify.html
@@ -1,1 +1,0 @@
-{{ include.text | mardownify | strip_html }}

--- a/_includes/smartify.html
+++ b/_includes/smartify.html
@@ -1,0 +1,1 @@
+{{ include.text | mardownify | strip_html }}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,7 +4,7 @@
   <div class="row">
     <div class="col-sm-10 col-sm-offset-1">
 
-{% capture title %}## {{ page.title }}{% endcapture %}{{ title | markdownify }}
+    <h2>{% include smartify text=page.title %}</h2>
 
 {{ content }}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,7 @@
 
 <article id="post{{ page.id | replace:"/","-" }}" class="post post{{ page.id | replace:"/","-" }}" itemscope itemtype="http://schema.org/Article">
 
-  <h2 class="title"><a href="{{ page.url }}" itemprop="name">{{ page.title }}</a></h2>
+  <h2 class="title"><a href="{{ page.url }}" itemprop="name">{% include smartify text=page.title %}</a></h2>
 
   <meta itemprop="about" content="{{ page.excerpt }}" />
   <meta itemprop="description" content="{{ page.excerpt }}" />

--- a/feed.xml
+++ b/feed.xml
@@ -21,7 +21,7 @@ json: false
    	<language>en-US</language>
     <description>{{ site.description }}</description>
     {% for post in site.posts limit:site.rss_limit %}<item>
-        <title>{{ post.title }}</title>
+        <title>{% include smartify text=post.title %}</title>
         <link>{{ url_base }}{{ post.url }}</link>
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
         <dc:creator>{{ post.author }}</dc:creator>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ permalink: /
   <li class="post">
     <div class="row">
         <div class="col-sm-9">
-            <a href="{{ url_base }}{{ page.url }}">{{ page.title }}</a>
+            <a href="{{ url_base }}{{ page.url }}">{% include smartify text=page.title %}</a>
         </div>
         <div class="col-sm-3 date">
             {{ page.date | date: '%B %d, %Y' }}


### PR DESCRIPTION
This change applies markdown rendering to titles.

Before:

```
The Files "in" the Computer -- Zoolander and the California Supreme Court
```

After:

```
The Files “in” the Computer – Zoolander and the California Supreme Court
```