### PR TITLE
add wikis to matrix, note about possibility of blog process

### DIFF
--- a/_posts/2015-11-18-tools-to-empower-open-collaboration.md
+++ b/_posts/2015-11-18-tools-to-empower-open-collaboration.md
@@ -79,7 +79,8 @@ I began by noting that the phrase "everything should be on GitHub", doesn't nece
 |:--------------|:-------------------|:-----------------------|:---------------------------------|:-------------------|
 | GitHub        | :heavy_check_mark: | :heavy_check_mark:     | :heavy_check_mark:               | :heavy_check_mark: |
 | (Text) Chat   | :heavy_check_mark: | :heavy_check_mark:     | :heavy_check_mark:               | :heavy_check_mark: |
-| Blogs         | :heavy_check_mark: | :x:                    | :heavy_check_mark:               | :heavy_check_mark: |
+| Wikis         | :heavy_check_mark: | :heavy_check_mark:     | :heavy_check_mark:               | :heavy_check_mark: |
+| Blogs         | :heavy_check_mark: | :x:[^git-blog]         | :heavy_check_mark:               | :heavy_check_mark: |
 | Google Docs   | :heavy_check_mark: | :x:[^tracked-changes]  | :x:[^links]                      | :heavy_check_mark: |
 | Microsft Word | :x:[^proprietary]  | :x:[^tracked-changes]  | :x:                              | :heavy_check_mark: |
 | Sharepoint    | :x:[^proprietary]  | :x:[^tracked-changes]  | :x:[^links]                      | :heavy_check_mark: |
@@ -98,6 +99,8 @@ Although I think it's the future of knowledge work, this develop-inspired workfl
 [How you work is just as important as what you work on](http://ben.balter.com/2015/09/21/open-source-behind-the-firewall/#how-you-work-is-as-important-as-what-you-work-on). I challenge you to take a critical look at your own workflow, and ask yourself if you're working the way you'd like to work, or just the way everyone else does.
 
 ---
+
+[^git-blog]: It's possible for a blog to capture and expose process if it is creating using tools such as GitHub and GitHub Pages, like this blog is. But this is not (yet) the case for the vast majority of blogs.
 
 [^tracked-changes]: While Google Docs and Microsoft Word can track changes (or you can version files manually via email), changes are tracked on a line-by-line or even character-by-character basis, making it hard to capture an entire revision in a single changeset. Compare a diff on GitHub (e.g., atomic commit) to the revision history menu on Google Docs or "track changes" in Microsoft Word.
 


### PR DESCRIPTION
I thought about commenting but figured I"d suggest a change instead. I guess their non-inclusion is an indicator of how far wikis have fallen off the radar as a general collaboration tool. Definitely did not live up to early hype, so perhaps non-inclusion warranted. Also suggested a seemingly obvious note about potential for blogs to expose process, exemplified by yours.