### PR TITLE
xml_escape the seo_description

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@
   <h2 class="title"><a href="{{ url_base }}{{ page.url }}" itemprop="name">{% include smartify text=page.title %}</a></h2>
 
   {% if page.description %}
-    {% assign seo_description = page.description | escape | markdownify | strip_html | strip_newlines %}
+    {% assign seo_description = page.description | escape | markdownify | strip_html | strip_newlines | xml_escape %}
     <meta itemprop="about" content="{{ seo_description }}" />
     <meta itemprop="description" content="{{ seo_description }}" />
   {% endif %}


### PR DESCRIPTION
Otherwise quotes can become a problem

<img width="627" alt="screen shot 2015-11-19 at 2 43 33 pm" src="https://cloud.githubusercontent.com/assets/237985/11286803/fec02494-8ecb-11e5-9f55-498ae781322e.png">
