### PR TITLE
Foregone -> forego (or forgo)

### DIFF
--- a/_posts/2016-01-15-how-to-derail-any-meeting.md
+++ b/_posts/2016-01-15-how-to-derail-any-meeting.md
@@ -29,7 +29,7 @@ With that in mind, here's how I'd update the *Simple Sabotage Field Manual* for 
 * **Don't do any work outside the meeting**. Use the meeting as a forcing function. Meetings are when your team does work. Even better, if you've called the meeting, don't send any materials in advance, or if you're an attendee, restate issues addressed in preparatory materials (which you didn't read).
 * Insist that the group **table the discussion to take a step back** and define with specificity *what you're solving for*, *the scope of the project*, and *the particular meeting's goals*. Assert that the group won't be able to reach a consensus until those questions have been answered.
 * If the discussion begins to gain momentum, ask **open ended, proccess-bassed questions** like *what does success look like?*, *what's our success metric?*, or *how do we measure our success metric?*.
-* Whenever you sense a decision nearing, insist that the group **foregone decision making** until stakeholders not originally invited to the meeting can have the opportunity to weigh in.
+* Whenever you sense a decision nearing, insist that the group **forego decision making** until stakeholders not originally invited to the meeting can have the opportunity to weigh in.
 
 *That's what I'd add to the list if I were giving it a refresh for 2016. What would you add? What corporate anti-patterns have you seen in your own organization? Do you have reason to suspect any of your colleagues are inadvertent sabatours?*
 


### PR DESCRIPTION
Good post. Just a quick tweak for a possible typo.