### PR TITLE
Updated `site.github` usage

### DIFF
--- a/_posts/2015-06-11-using-github-pages-to-showcase-your-orgs-open-source-efforts.md
+++ b/_posts/2015-06-11-using-github-pages-to-showcase-your-orgs-open-source-efforts.md
@@ -135,8 +135,8 @@ The problem with this approach, is that as you add more projects, you have to co
 In addition to Markdown, Jekyll also supports a lightweight templating engine called [Liquid](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers). Liquid allows us to inject a bit of dynamic logic into the otherwise static site. If you're familiar with basic programatic concepts, it supports things like `while`, `if`, and `for` statements. To list all the open source project's in our organization's we might write:
 
 {% highlight liquid %}{% raw %}
-{% for repository in site.github.repositories %}
-  * {{ repository.title }}
+{% for repository in site.github.public_repositories %}
+  * {{ repository.name }}
 {% endfor %}
 {% endraw %}{% endhighlight %}
 


### PR DESCRIPTION
In particular, `site.github.repositories` seems to be replaced with `site.github.public_repositories` and `repository.title` is now `repository.name`.