### PR TITLE
fix ShellCheck code linter warnings

### DIFF
--- a/script/new
+++ b/script/new
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Creates a new post with today's date
 # Usage: script/new [post-slug]
 
@@ -6,12 +6,12 @@ set -e
 
 date=$(date +"%Y-%m-%d")
 file="_posts/$date-$1.md"
-title=$(echo "$1" | sed s/-/\ /g)
+title=${1//-/ }
 
-git checkout -B $1
+git checkout -B "$1"
 
 touch "$file"
-echo "---\ntitle: $title\ndescription:\n---\n\n" > $file
+echo -e "---\ntitle: $title\ndescription:\n---\n\n" > "$file"
 
 git add "$file"
 git commit -m "Create $file"


### PR DESCRIPTION
use echo -e to expand escape sequences (SC2028)
also requires #!/bin/bash instead of #!/bin/sh (SC2039)
use bash substring substitution instead of sed (SC2001)
ex: ${var//Pattern/Replacement}