### PR TITLE
Fix broken link to @kneath's "Taste" blog post

### DIFF
--- a/_posts/2015-08-12-the-zen-of-github.md
+++ b/_posts/2015-08-12-the-zen-of-github.md
@@ -3,7 +3,7 @@ title: The Zen of GitHub
 description: Whether you call it taste, culture, or zen, there are underlying assumptions that members of an organization rely on to resolve ambiguity in pursuit of the organization's mission.
 ---
 
-I've got a [broadside](https://en.wikipedia.org/wiki/Broadside_(printing)) hanging in my office which reads "ZEN" in bright red, hand-typeset lettering. It's what we call *the Zen of GitHub*. It's the first words displayed each time a GitHub server spins up, and it's the philosophy that has historically underpinned most major decisions at GitHub, both technical and otherwise. @kneath published [a great write up as to the how and why](http://warpspire.com/posts/taste/) that GitHub Zen came to be. Speaking to the contrast between Apple and Microsoft, he wrote:
+I've got a [broadside](https://en.wikipedia.org/wiki/Broadside_(printing)) hanging in my office which reads "ZEN" in bright red, hand-typeset lettering. It's what we call *the Zen of GitHub*. It's the first words displayed each time a GitHub server spins up, and it's the philosophy that has historically underpinned most major decisions at GitHub, both technical and otherwise. @kneath published [a great write up as to the how and why](http://warpspire.com/posts/taste) that GitHub Zen came to be. Speaking to the contrast between Apple and Microsoft, he wrote:
 
 > \[A]n organization’s taste is defined by the process and style in which they make design decisions. What features belong in our product? Which prototype feels better? Do we need more iterations, or is this good enough? Are these questions answered by tools? By a process? By a person? Those answers are the essence of taste. In other words, an organization’s taste is the way the organization makes design decisions.
 


### PR DESCRIPTION
This PR fixes the broken link to @kneath's ["Taste" blog post](http://warpspire.com/posts/taste). 

(Looks like trailing slashes no longer work after Kyle's blog reboot)