### PR TITLE
Fixed the DNS reference on blog article

### DIFF
--- a/_posts/2021-09-01-how-i-re-over-engineered-my-home-network.md
+++ b/_posts/2021-09-01-how-i-re-over-engineered-my-home-network.md
@@ -98,7 +98,7 @@ services:
     # I'm pretty sure cloudflared doesn't use the bootstrap server, so we define it here too
     dns:
       - 1.1.1.2
-      - 1.1.0.2
+      - 1.0.0.2
     networks:
       net:
         ipv4_address: 10.0.0.2


### PR DESCRIPTION
You accepted my pull request for this fix in the code but I guess the article didn't get updated.

Question: Is there a way to dynamically reference a section of the code? This would avoid synchronization issues in the future? Point me where and I'll implement it for you!

-----
[View rendered _posts/2021-09-01-how-i-re-over-engineered-my-home-network.md](https://github.com/RyanCorrigal/benbalter.github.com/blob/patch-2/_posts/2021-09-01-how-i-re-over-engineered-my-home-network.md)