### PR TITLE
Add agent-discovery Link headers and robots.txt Content-Signal

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -15,6 +15,10 @@
   Cross-Origin-Resource-Policy: same-origin
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' data: https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://cloudflareinsights.com https://api.github.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
   Cache-Control: public, max-age=120, stale-while-revalidate=86400
+  Link: </sitemap-index.xml>; rel="sitemap"; type="application/xml"
+  Link: </feed.xml>; rel="alternate"; type="application/atom+xml"; title="Atom Feed"
+  Link: </llms.txt>; rel="llms-txt"; type="text/plain"
+  Link: </vcard.vcf>; rel="author"; type="text/vcard"
 
 # Immutable hashed assets (JS, CSS, images, fonts) - 1 year cache
 /assets/*

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -45,7 +45,14 @@ export const GET: APIRoute = ({ site }) => {
   // Use the site URL from Astro config for portability
   const siteUrl = site?.origin ?? 'https://ben.balter.com';
   
+  // Content Signals (contentsignals.org, draft-romm-aipref-contentsignals)
+  // Declares AI content usage preferences: search indexing, AI training, and
+  // AI input (retrieval for generative answers) are all welcomed for this
+  // public personal blog, consistent with the site's openly-published llms.txt.
+  const contentSignal = 'Content-Signal: search=yes, ai-train=yes, ai-input=yes';
+
   const content = `User-agent: *
+${contentSignal}
 ${disallowLines}
 Allow: /
 Sitemap: ${siteUrl}/sitemap-index.xml


### PR DESCRIPTION
- Add Content-Signal directive (search/ai-train/ai-input=yes) to robots.txt per the contentsignals.org / draft-romm-aipref-contentsignals proposal.
- Add RFC 8288 Link response headers site-wide pointing agents at the sitemap, Atom feed, llms.txt, and vCard.