### PR TITLE
New post: The brag doc

### DIFF
--- a/src/content/posts/2026-04-27-the-brag-doc.md
+++ b/src/content/posts/2026-04-27-the-brag-doc.md
@@ -1,0 +1,62 @@
+---
+title: The brag doc
+description: "Why you need a running record of your wins—and how to keep one without dying of embarrassment"
+tldr: "Nobody's compiling your stats for you. Keep a ship log of your impact, update it weekly, and use it to fight recency bias, ace self-assessments, and build your promotion case."
+---
+
+Here's the best career advice I ever received as a product manager: "product-manage your own career." I wish I'd internalized it sooner. Early in my career, I stayed quiet and did good work, assuming the right people would notice. Spoiler: they didn't—not because the work wasn't good, but because nobody else was tracking it.
+
+Treat yourself as a product. What are your features? What are your bugs? What does your roadmap look like? And critically: who's keeping the changelog?
+
+## Nobody's keeping score for you
+
+Unless you're a professional athlete, nobody's compiling your stats. Your manager has their own deliverables, their own manager to impress, and a dozen other direct reports. They aren't maintaining a highlight reel of your career. That's your job.
+
+In remote organizations, this problem compounds. There's no hallway reputation, no casual office face time, no lunch with the VP where you happen to mention your project. If people don't see your work in pull requests, issues, or public discussions, they don't know you exist. [Working in the open](/2015/11/12/why-urls/) creates a natural paper trail—public pull requests, documented decisions, visible contributions—but that trail only matters if you curate it.
+
+## The ship log
+
+Maintain a "ship log"—call it a "brag doc," "hype doc," "smile file," whatever gets you to actually use it. Each time you hit a milestone, record it with its impact and any relevant metrics. Async work hands you a head start: your contributions are already timestamped and linkable.
+
+Your ship log combats impostor syndrome, makes annual self-assessments trivially easy to write, and keeps your professional profiles current. **If you didn't log it, it didn't happen.**
+
+The format doesn't matter—a Google Doc, Apple Notes, a text file in your home directory. What matters is that it's easy to update and always within reach. Every Friday, spend five minutes adding bullets: what you shipped, what you unblocked, what decisions you influenced.
+
+## What makes a good entry
+
+Effective ship log entries are:
+
+- **Specific and linked.** "Improved documentation" is vague. "Rewrote the onboarding docs, resulting in 40% fewer support tickets from new hires ([link to the issue])" is evidence.
+- **Impact-focused.** List outcomes, not activities. "Attended twelve planning meetings" says nothing. "Proposed the architecture that shipped to production" tells a story.
+- **Continuous.** Don't wait until review season. Update weekly, while the details are fresh.
+- **Shareable.** Your log isn't a secret diary. Share highlights with your manager regularly. The best time to make your case for promotion is months before the conversation happens.
+
+Don't limit yourself to completed deliverables. Screenshot the email where a stakeholder said your proposal changed their thinking. Note the meeting where your question reframed the entire discussion. Record the mentoring conversation that helped a junior engineer get unstuck. These qualitative moments are often more compelling in a promotion case than a list of closed tickets.
+
+## Climbing Cringe Mountain
+
+Yes, maintaining a brag doc feels awkward. There's a reason people call it "climbing Cringe Mountain." We're conditioned to believe good work speaks for itself—that tracking your wins is unseemly.
+
+It's not.
+
+The alternative is being invisible. And invisible people don't get promoted—they get overlooked, then they leave. Ship early, [show your work](/2022/02/16/leaders-show-their-work/), and keep the receipts.
+
+If sharing your wins feels gross, reframe it: you're not bragging, you're making your manager's job easier. When promotion conversations come around, you'll have months of evidence instead of a frantic scramble to remember last quarter.
+
+## Fighting recency bias
+
+Here's the real killer: recency bias. Your manager (and you) will tend to remember only the last few weeks when evaluation season arrives. That critical project you shipped in February? Without a record, it might as well not have happened by December.
+
+A ship log is your defense. When it's time for self-assessments, you open the doc and the year's work is right there—specific, linked, and impact-focused. No scrambling, no guessing, no accidental amnesia about Q1.
+
+## Make it a habit
+
+A brag doc only works if you actually maintain it. Some practical tips:
+
+- **Set a weekly reminder.** Friday afternoon, five minutes. What did you ship? What did you unblock? What decisions did you influence?
+- **Ship something visible every week.** It doesn't have to be a major feature—fixing a bug, improving documentation, or sharing a design sketch counts. Make shipping a habit, not an event.
+- **Share progress within a day or two.** If you've been working on something for more than a day or two without sharing any progress, you're probably holding on too long. Unshipped work is invisible work.
+- **Feed your self-assessments.** When review season comes, your log *is* your self-assessment draft. Copy, paste, polish.
+- **Build your promotion packet early.** The best promotion cases aren't written in a weekend—they're assembled over months from a well-maintained log.
+
+Nobody else will manage your career. Your company manages your role. You manage your trajectory. Start the doc today—future you will be grateful.


### PR DESCRIPTION
New blog post from cut 'Corporate Self-Care' book content:
- Ship log / brag doc concept
- 'Climbing Cringe Mountain' — overcoming self-promotion discomfort
- Fighting recency bias in performance reviews
- Product-manage your career framework

~870 words.