### PR TITLE
New post: How to one-on-one

### DIFF
--- a/src/content/posts/2026-04-27-one-on-one-playbook.md
+++ b/src/content/posts/2026-04-27-one-on-one-playbook.md
@@ -1,0 +1,60 @@
+---
+title: "How to one-on-one"
+description: "Most 1:1s waste your team's only protected synchronous time on status updates. Here's how to run ones worth showing up for."
+tldr: "Stop using 1:1s for status updates. Prep async, focus on career growth, coaching, feedback, and human connection, and protect the time like it matters—because it does."
+---
+
+It's Thursday afternoon. Your direct report sits down and reads from a list: "Closed three bugs, reviewed two PRs, started the migration doc." You nod. They nod. Thirty minutes pass without either of you saying anything that couldn't have been a comment on an issue.
+
+Most 1:1s fail in one of three ways. The most common: spending your team's only protected synchronous time on information that belongs in writing. The second: sugarcoating hard feedback until nobody walks away clear on what actually needs to change. The third is quieter—the 1:1 that keeps getting canceled because "something came up," until the relationship slowly starves.
+
+## What belongs in a 1:1
+
+Great 1:1s focus on topics that only work synchronously. Five categories keep coming up:
+
+- **Career growth and development.** Where do you want to be in a year? What skills do you want to develop? These conversations require back-and-forth exploration, picking up on what's left unsaid, and nuanced guidance that doesn't fit in an issue comment.
+- **Coaching and problem-solving.** When you're stuck on an interpersonal challenge, unsure how to approach a sensitive topic, or wrestling with a decision that has no clear right answer, talking it through with someone who has context beats wrestling with it alone.
+- **Feedback and calibration.** Feedback—giving and receiving—lands better in real-time. Tone and body language provide context that text can't, and you can clarify misunderstandings immediately. Written feedback can feel blunt or land wrong; spoken feedback invites dialogue.
+- **Human connection.** Remote work can be isolating. 1:1s let you check in as humans, not just workers. How are you actually doing? Building genuine relationships requires face-to-face time, even if that face is on a screen.
+- **Clearing the air.** If there's tension, frustration, or something unsaid, 1:1s are the place to address it directly. These conversations are almost always better synchronously than through a wall of text.
+
+What *doesn't* belong: status updates, information transfer, and approval requests. If you're listing what you shipped last week, you're wasting the meeting. Your manager should see your work before the 1:1, not hear about it during. Approvals create bottlenecks—ask async. Information sharing belongs in a doc sent beforehand. Use synchronous time to discuss implications, not convey facts.
+
+## How to prepare
+
+Great 1:1s start before the meeting does.
+
+Keep a **running shared agenda**—a Google Doc, a GitHub issue, whatever works—where both parties add topics throughout the week. When something comes up worth discussing, add it immediately instead of trying to remember later.
+
+Add context to each item. Don't just write "career growth"—write "I've been thinking about whether to pursue the tech lead path or people management, and I'd like to talk through the tradeoffs." The more context upfront, the more productive the conversation. Prioritize ruthlessly—you won't cover everything every week, and if something keeps rolling without getting discussed, that tells you something about its actual importance.
+
+A good test of your preparation: could you cancel the meeting without losing anything? If yes, you either don't have enough prepared or you're covering topics better handled async.
+
+## How to run one
+
+Start with the human, not the agenda. Take a few minutes to check in personally. This isn't small talk—it's the relationship that makes hard conversations possible later.
+
+**Ask questions more than you give answers.** For managers, your job isn't to solve every problem—it's to help your report think through problems themselves. "What options are you considering?" is often more useful than "Here's what you should do." For ICs, don't just wait to be told what to do—challenge assumptions and push back.
+
+Follow the agenda, but hold it loosely. If a topic opens up a more important conversation, follow it. The rest can wait.
+
+**Make space for what's unsaid.** The most important topics often aren't on the agenda because they're hard to articulate or feel risky to raise. Make it safe by raising difficult topics yourself and responding non-defensively when others do.
+
+**End with clear next steps.** What actions came out of this? Who's doing what by when? Document them somewhere durable so they don't get lost. Leaders who [show their work](/2022/02/16/leaders-show-their-work/) in shared docs make this easy—the same transparency that helps distributed teams function day-to-day makes 1:1 follow-through automatic.
+
+## Skip-levels: why they matter
+
+Skip-level 1:1s—regular conversations with your manager's manager—build rapport and broader perspective. They're typically less frequent (monthly or quarterly), but they matter for career visibility and organizational context. They give senior leaders unfiltered signal about how the team is actually doing, and they give ICs a line of sight into strategy they wouldn't otherwise have.
+
+## Anti-patterns to avoid
+
+- **The ghost meeting.** Neither party prepares, there's no agenda, and you spend thirty minutes in a conversational holding pattern. If you have nothing to discuss, either something is going well or something is going unaddressed—figure out which.
+- **The cancellation cascade.** 1:1s keep getting canceled because "something came up." That signals the relationship isn't a priority. Protect the time, especially for remote relationships where it's harder to connect informally.
+- **The manager monologue.** The manager talks the whole time, sharing information, giving advice, or thinking out loud. 1:1s should be conversations, not presentations.
+- **The reverse 1:1.** The entire meeting becomes the report briefing the manager on the work. If your report is educating you for thirty minutes, you owe them a different format, not a recurring appointment.
+
+## The real test
+
+Your 1:1s are a microcosm of how you lead. Shared agendas, documented outcomes, async preparation—every practice that makes a 1:1 great is the same practice that makes a distributed team work. If you [manage like an engineer](/2023/01/10/manage-like-an-engineer/), you already have the instincts: treat the meeting like a system, instrument it, and iterate.
+
+Get the 1:1 right and the rest follows.


### PR DESCRIPTION
New blog post from cut 'How to One-on-One' book content:
- Five 1:1 topic categories (career, coaching, feedback, connection, clearing air)
- Prep and facilitation guidance
- Skip-level 1:1s
- Anti-patterns (ghost meeting, cancellation cascade)

~1,010 words.