### PR TITLE
Add /resume.docx endpoint for downloadable Word resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "astro-embed": "^0.13.0",
         "astro-expressive-code": "^0.42.0",
         "astro-seo": "^1.1.0",
+        "docx": "^9.7.1",
         "fastest-levenshtein": "^1.0.16",
         "marked": "^18.0.4",
         "medium-zoom": "^1.1.0",
@@ -5572,7 +5573,6 @@
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -5582,7 +5582,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -8555,6 +8554,12 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -9089,6 +9094,41 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/docx": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.7.1.tgz",
+      "integrity": "sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/docx/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/dom-serializer": {
@@ -12091,6 +12131,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hashery": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
@@ -12698,6 +12748,12 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -12760,7 +12816,6 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -13671,6 +13726,60 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.28",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
@@ -13747,6 +13856,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -16093,6 +16211,12 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -17431,6 +17555,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -20173,6 +20303,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -24680,6 +24816,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xml-naming": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "astro-embed": "^0.13.0",
     "astro-expressive-code": "^0.42.0",
     "astro-seo": "^1.1.0",
+    "docx": "^9.7.1",
     "fastest-levenshtein": "^1.0.16",
     "marked": "^18.0.4",
     "medium-zoom": "^1.1.0",

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -83,7 +83,7 @@ const resumeSchema = generateResumeSchema({
       <p class="summary-text">{summary}</p>
       <p class="resume-aux">
         Also available on <a href="https://www.linkedin.com/in/benbalter/" target="_blank" rel="me noopener noreferrer">LinkedIn</a>.
-        Use your browser's print-to-PDF to save a copy.
+        <a href="/resume.docx" download>Download as Word</a>, or use your browser's print-to-PDF to save a copy.
       </p>
     </section>
   )}

--- a/src/pages/resume.docx.ts
+++ b/src/pages/resume.docx.ts
@@ -1,0 +1,393 @@
+/**
+ * Resume — Word (.docx) export
+ *
+ * Renders the same resume data shown on /resume as a downloadable Word
+ * document. Pulls from the `pages` (resume) and `resume-positions` content
+ * collections so the .docx never drifts from the HTML page.
+ *
+ * `output: 'static'` means this runs at build time and Astro writes the
+ * Response body to dist-astro/resume.docx. The body is raw ZIP bytes — return
+ * the Buffer from Packer.toBuffer() directly and never stringify it, or the
+ * archive corrupts and Word refuses to open the file.
+ */
+
+import type { APIRoute } from 'astro';
+import { getEntry, getCollection, type CollectionEntry } from 'astro:content';
+import { marked, type Token, type Tokens } from 'marked';
+import {
+  Document,
+  Packer,
+  Paragraph,
+  TextRun,
+  ExternalHyperlink,
+  HeadingLevel,
+  TabStopType,
+  BorderStyle,
+} from 'docx';
+import { formatResumeDate } from '../utils/post-urls';
+import { siteConfig } from '../config';
+
+// Brand accent (matches --color-primary on the HTML resume).
+const ACCENT = '337AB7';
+const ACCENT_DARK = '204D6F';
+const HYPERLINK = '0563C1';
+const MUTED = '555555';
+
+// ---------------------------------------------------------------------------
+// Markdown → docx
+//
+// Position bodies are markdown: `#####` subheadings plus `-` bullet lists with
+// inline `[text](url)` links and the occasional bold/italic. marked nests
+// inline content (list → item → text token → .tokens), so we walk it
+// recursively. Any token type we don't explicitly handle falls back to its
+// plain text — a missing link is acceptable, a crash is not.
+// ---------------------------------------------------------------------------
+
+interface RunStyle {
+  bold?: boolean;
+  italics?: boolean;
+  hyperlink?: boolean;
+}
+
+/** Turn an accumulated style into the TextRun options docx expects. */
+function runOpts(style: RunStyle): { bold?: boolean; italics?: boolean; color?: string; underline?: object } {
+  return {
+    ...(style.bold ? { bold: true } : {}),
+    ...(style.italics ? { italics: true } : {}),
+    ...(style.hyperlink ? { color: HYPERLINK, underline: {} } : {}),
+  };
+}
+
+/** Render inline tokens to docx runs (TextRun / ExternalHyperlink). */
+function renderInline(tokens: Token[], style: RunStyle = {}): (TextRun | ExternalHyperlink)[] {
+  const runs: (TextRun | ExternalHyperlink)[] = [];
+
+  for (const token of tokens) {
+    switch (token.type) {
+      case 'text': {
+        const t = token as Tokens.Text;
+        if (t.tokens && t.tokens.length > 0) {
+          runs.push(...renderInline(t.tokens, style));
+        } else {
+          runs.push(new TextRun({ text: t.text, ...runOpts(style) }));
+        }
+        break;
+      }
+      case 'strong':
+        runs.push(...renderInline((token as Tokens.Strong).tokens, { ...style, bold: true }));
+        break;
+      case 'em':
+        runs.push(...renderInline((token as Tokens.Em).tokens, { ...style, italics: true }));
+        break;
+      case 'codespan':
+        runs.push(new TextRun({ text: (token as Tokens.Codespan).text, font: 'Consolas', ...runOpts(style) }));
+        break;
+      case 'link': {
+        const link = token as Tokens.Link;
+        runs.push(
+          new ExternalHyperlink({
+            link: link.href,
+            children: renderInline(link.tokens, { ...style, hyperlink: true }),
+          })
+        );
+        break;
+      }
+      case 'br':
+        runs.push(new TextRun({ break: 1 }));
+        break;
+      case 'escape':
+        runs.push(new TextRun({ text: (token as Tokens.Escape).text, ...runOpts(style) }));
+        break;
+      case 'html':
+        // Strip stray HTML (e.g. markdownlint comments) — emit nothing.
+        break;
+      default:
+        if ('text' in token && typeof token.text === 'string') {
+          runs.push(new TextRun({ text: token.text, ...runOpts(style) }));
+        }
+    }
+  }
+
+  return runs;
+}
+
+/** Collect the inline tokens out of a list item (handles loose + tight items). */
+function listItemInline(item: Tokens.ListItem): Token[] {
+  const inline: Token[] = [];
+  for (const token of item.tokens) {
+    if (token.type === 'list') continue; // nested lists handled separately
+    if ('tokens' in token && Array.isArray(token.tokens)) {
+      inline.push(...token.tokens);
+    } else {
+      inline.push(token);
+    }
+  }
+  return inline;
+}
+
+/** Strip HTML comments (markdownlint directives) and trailing whitespace. */
+function cleanHeading(text: string): string {
+  return text.replace(/<!--[\s\S]*?-->/g, '').trim();
+}
+
+/** Render a position's markdown body to a flat list of docx Paragraphs. */
+function renderMarkdownBody(body: string): Paragraph[] {
+  const tokens = marked.lexer(body);
+  const paragraphs: Paragraph[] = [];
+
+  const walk = (toks: Token[], bulletLevel = 0) => {
+    for (const token of toks) {
+      switch (token.type) {
+        case 'heading': {
+          const text = cleanHeading((token as Tokens.Heading).text);
+          if (text) {
+            paragraphs.push(
+              new Paragraph({
+                spacing: { before: 120, after: 40 },
+                children: [new TextRun({ text, bold: true, color: ACCENT_DARK, size: 21 })],
+              })
+            );
+          }
+          break;
+        }
+        case 'list': {
+          for (const item of (token as Tokens.List).items) {
+            paragraphs.push(
+              new Paragraph({
+                bullet: { level: bulletLevel },
+                spacing: { after: 40 },
+                children: renderInline(listItemInline(item)),
+              })
+            );
+            // Nested lists, if any.
+            const nested = item.tokens.find((t) => t.type === 'list');
+            if (nested) walk([nested], bulletLevel + 1);
+          }
+          break;
+        }
+        case 'paragraph':
+          paragraphs.push(
+            new Paragraph({
+              spacing: { after: 80 },
+              children: renderInline((token as Tokens.Paragraph).tokens),
+            })
+          );
+          break;
+        // 'space' and anything else: ignore.
+      }
+    }
+  };
+
+  walk(tokens);
+  return paragraphs;
+}
+
+// ---------------------------------------------------------------------------
+// Document scaffold helpers
+// ---------------------------------------------------------------------------
+
+/** Uppercase section heading with an accent rule underneath (mirrors h2). */
+function sectionHeading(text: string): Paragraph {
+  return new Paragraph({
+    heading: HeadingLevel.HEADING_1,
+    spacing: { before: 280, after: 120 },
+    border: { bottom: { style: BorderStyle.SINGLE, size: 12, color: ACCENT, space: 2 } },
+    children: [
+      new TextRun({ text: text.toUpperCase(), bold: true, color: ACCENT_DARK, size: 24, characterSpacing: 30 }),
+    ],
+  });
+}
+
+/** A title line with a right-aligned date badge (uses a right tab stop). */
+function titleWithDate(title: string, dateText: string, opts: { titleSize?: number; titleColor?: string } = {}): Paragraph {
+  return new Paragraph({
+    tabStops: [{ type: TabStopType.RIGHT, position: 9360 }],
+    spacing: { after: 40 },
+    children: [
+      new TextRun({ text: title, bold: true, size: opts.titleSize ?? 22, ...(opts.titleColor ? { color: opts.titleColor } : {}) }),
+      new TextRun({ text: `\t${dateText}`, italics: true, color: MUTED, size: 18 }),
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint
+// ---------------------------------------------------------------------------
+
+export const GET: APIRoute = async () => {
+  const resumePage = await getEntry('pages', 'resume');
+  if (!resumePage) {
+    throw new Error('Resume page data not found');
+  }
+  const { degrees, certifications, skills, summary } = resumePage.data;
+
+  // Positions, newest first, grouped by employer (same logic as resume.astro).
+  const sortedPositions = (await getCollection('resume-positions')).sort(
+    (a: CollectionEntry<'resume-positions'>, b: CollectionEntry<'resume-positions'>) =>
+      new Date(b.data.start_date).getTime() - new Date(a.data.start_date).getTime()
+  );
+
+  const employerGroups = new Map<string, CollectionEntry<'resume-positions'>[]>();
+  for (const position of sortedPositions) {
+    if (!employerGroups.has(position.data.employer)) {
+      employerGroups.set(position.data.employer, []);
+    }
+    employerGroups.get(position.data.employer)!.push(position);
+  }
+
+  const children: Paragraph[] = [];
+
+  // --- Header: name + contact strip ---------------------------------------
+  children.push(
+    new Paragraph({
+      spacing: { after: 40 },
+      children: [new TextRun({ text: siteConfig.author, bold: true, size: 44, color: ACCENT_DARK })],
+    })
+  );
+  children.push(
+    new Paragraph({
+      border: { bottom: { style: BorderStyle.SINGLE, size: 18, color: ACCENT, space: 4 } },
+      spacing: { after: 160 },
+      children: [
+        new TextRun({ text: 'Washington, DC  ·  ', color: MUTED, size: 18 }),
+        new ExternalHyperlink({ link: `mailto:${siteConfig.email}`, children: [new TextRun({ text: siteConfig.email, color: HYPERLINK, size: 18 })] }),
+        new TextRun({ text: '  ·  ', color: MUTED, size: 18 }),
+        new ExternalHyperlink({ link: siteConfig.url, children: [new TextRun({ text: 'ben.balter.com', color: HYPERLINK, size: 18 })] }),
+        new TextRun({ text: '  ·  ', color: MUTED, size: 18 }),
+        new ExternalHyperlink({ link: siteConfig.linkedinUrl, children: [new TextRun({ text: 'linkedin.com/in/benbalter', color: HYPERLINK, size: 18 })] }),
+      ],
+    })
+  );
+
+  // --- Summary -------------------------------------------------------------
+  if (summary) {
+    children.push(
+      new Paragraph({
+        spacing: { after: 80 },
+        children: [new TextRun({ text: summary, italics: true, size: 21 })],
+      })
+    );
+  }
+
+  // --- Areas of focus (skills) --------------------------------------------
+  if (skills && skills.length > 0) {
+    children.push(sectionHeading('Areas of Focus'));
+    for (const group of skills as Array<{ group: string; items: string[] }>) {
+      children.push(
+        new Paragraph({
+          spacing: { before: 80, after: 20 },
+          children: [new TextRun({ text: group.group, bold: true, color: ACCENT_DARK, size: 19, allCaps: true, characterSpacing: 20 })],
+        })
+      );
+      children.push(
+        new Paragraph({
+          spacing: { after: 40 },
+          children: [new TextRun({ text: group.items.join('  ·  '), size: 19 })],
+        })
+      );
+    }
+  }
+
+  // --- Experience ----------------------------------------------------------
+  children.push(sectionHeading('Experience'));
+  for (const [employer, positions] of employerGroups) {
+    children.push(
+      new Paragraph({
+        spacing: { before: 200, after: 40 },
+        children: [new TextRun({ text: employer, bold: true, size: 26, color: ACCENT })],
+      })
+    );
+    for (const position of positions) {
+      const start = formatResumeDate(position.data.start_date) ?? 'Unknown';
+      const end = position.data.end_date ? formatResumeDate(position.data.end_date) ?? 'Unknown' : 'Present';
+      children.push(titleWithDate(position.data.title, `${start}–${end}`));
+      children.push(...renderMarkdownBody(position.body ?? ''));
+    }
+  }
+
+  // --- Education -----------------------------------------------------------
+  if (degrees && degrees.length > 0) {
+    children.push(sectionHeading('Education'));
+    for (const degree of degrees as Array<{ school: string; degree: string; date: string }>) {
+      children.push(titleWithDate(degree.school, formatResumeDate(degree.date) ?? '', { titleSize: 22 }));
+      children.push(new Paragraph({ spacing: { after: 120 }, children: [new TextRun({ text: degree.degree, size: 20 })] }));
+    }
+  }
+
+  // --- Certifications ------------------------------------------------------
+  if (certifications && certifications.length > 0) {
+    type Cert = { authority: string; name: string; url?: string; expired?: boolean; category?: string };
+    const certs = certifications as Cert[];
+    const professional = certs.filter((c) => (c.category ?? 'professional') === 'professional');
+    const personal = certs.filter((c) => c.category === 'personal');
+
+    const renderCert = (cert: Cert) => {
+      const nameRuns: (TextRun | ExternalHyperlink)[] = [
+        cert.url
+          ? new ExternalHyperlink({ link: cert.url, children: [new TextRun({ text: cert.name, color: HYPERLINK, underline: {}, size: 20 })] })
+          : new TextRun({ text: cert.name, size: 20 }),
+      ];
+      if (cert.expired) {
+        nameRuns.push(new TextRun({ text: '  (Expired)', size: 16, color: MUTED, italics: true }));
+      }
+      return [
+        new Paragraph({
+          spacing: { before: 80, after: 0 },
+          children: [new TextRun({ text: cert.authority.toUpperCase(), bold: true, size: 15, color: MUTED, characterSpacing: 15 })],
+        }),
+        new Paragraph({ spacing: { after: 40 }, children: nameRuns }),
+      ];
+    };
+
+    children.push(sectionHeading('Certifications'));
+    if (professional.length > 0) {
+      children.push(
+        new Paragraph({
+          spacing: { before: 80, after: 20 },
+          children: [new TextRun({ text: 'Professional', bold: true, color: ACCENT_DARK, size: 19, allCaps: true, characterSpacing: 20 })],
+        })
+      );
+      for (const cert of professional) children.push(...renderCert(cert));
+    }
+    if (personal.length > 0) {
+      children.push(
+        new Paragraph({
+          spacing: { before: 160, after: 20 },
+          children: [new TextRun({ text: 'Personal interests', bold: true, color: ACCENT_DARK, size: 19, allCaps: true, characterSpacing: 20 })],
+        })
+      );
+      for (const cert of personal) children.push(...renderCert(cert));
+    }
+  }
+
+  const doc = new Document({
+    creator: siteConfig.author,
+    title: 'Ben Balter — Resume',
+    description: resumePage.data.description,
+    styles: {
+      default: {
+        document: { run: { font: 'Calibri', size: 20 } },
+      },
+    },
+    sections: [
+      {
+        properties: {
+          page: { margin: { top: 720, bottom: 720, left: 720, right: 720 } },
+        },
+        children,
+      },
+    ],
+  });
+
+  // Buffer is a Uint8Array → valid binary BodyInit. Do NOT stringify, or the
+  // ZIP bytes get UTF-8 re-encoded and Word refuses to open the file.
+  const buffer = await Packer.toBuffer(doc);
+
+  return new Response(new Uint8Array(buffer), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'Content-Disposition': 'attachment; filename="ben-balter-resume.docx"',
+    },
+  });
+};

--- a/src/pages/resume.docx.ts
+++ b/src/pages/resume.docx.ts
@@ -127,7 +127,13 @@ function listItemInline(item: Tokens.ListItem): Token[] {
 
 /** Strip HTML comments (markdownlint directives) and trailing whitespace. */
 function cleanHeading(text: string): string {
-  return text.replace(/<!--[\s\S]*?-->/g, '').trim();
+  let current = text;
+  let previous: string;
+  do {
+    previous = current;
+    current = current.replace(/<!--[\s\S]*?-->/g, '');
+  } while (current !== previous);
+  return current.trim();
 }
 
 /** Render a position's markdown body to a flat list of docx Paragraphs. */


### PR DESCRIPTION
## Summary

Adds an Astro endpoint at `/resume.docx` that renders the resume as a downloadable, formatted Word document, plus a "Download as Word" link on the resume page.

The endpoint pulls from the same content collections as `/resume` (the `pages/resume` entry and `resume-positions`), so the Word doc never drifts from the HTML page. It produces:

- Name + contact strip with an accent rule
- Italic summary
- Areas of Focus (skills)
- Experience grouped by employer with right-aligned date ranges
- Education and certifications (Professional / Personal)

Each position's markdown body (`#####` subheadings, bulleted lists, `[links](…)`) is converted to proper Word headings, bullets, and live hyperlinks via a small recursive `marked` → `docx` renderer. Stray markdownlint HTML comments are stripped.

Returns raw ZIP bytes with `Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document` and `Content-Disposition: attachment; filename="ben-balter-resume.docx"`. Since the site builds with `output: 'static'`, this runs at build time and writes `dist-astro/resume.docx`.

## Verification

- `npm run check` — 0 errors
- `npm run build` — emits `dist-astro/resume.docx` (~17.7 KB)
- `file` reports "Microsoft Word 2007+"; `unzip -l` shows valid OOXML parts (`[Content_Types].xml`, `word/document.xml`)
- Content check: all sections present, correct reading order, 20 working hyperlinks, no stray markdownlint comments

Not yet opened in Word/Pages (neither installed on the build machine) — worth a quick visual look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)