### PR TITLE
Fix lychee broken-link report (#1884)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -46,6 +46,21 @@ jobs:
       - name: Validate HTML (html-validate)
         run: npm run lint-html
 
+      - name: Strip standard.site link tags before link check
+        # The spec-required <link rel="site.standard.*" href="at://…"> tags (one
+        # per post, plus the homepage publication tag) carry AT Protocol URIs.
+        # lychee can't parse the at:// scheme — the colons in did:plc:… read as an
+        # invalid port — so it emits a hard parse error that no --exclude,
+        # --scheme, --remap, or .lycheeignore rule can suppress (they all run
+        # after URL parsing). These tags are verification infrastructure, not
+        # content links, so we drop them from this throwaway build before
+        # checking. Production output is unaffected: links.yml builds its own
+        # dist-astro and never deploys it. Runs after lint-html so the real
+        # markup is validated first.
+        run: |
+          find dist-astro -name '*.html' -print0 \
+            | xargs -0 sed -i -E 's#<link[^>]*rel="site\.standard\.(document|publication)"[^>]*>##g'
+
       - name: Restore lychee cache
         uses: actions/cache@v5
         with:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -19,10 +19,11 @@
 ^https?://127\.0\.0\.1
 ^https?://example\.(com|org|net)
 
-# AT Protocol URIs (at://did:plc:.../...) — emitted as standard.site
-# rel="site.standard.document"/"site.standard.publication" link tags. The
-# at:// scheme isn't resolvable over HTTP, so lychee can't (and shouldn't) check it.
-^at://
+# Note: standard.site rel="site.standard.document"/"site.standard.publication"
+# link tags carry at:// AT Protocol URIs that lychee can't parse (the colons in
+# did:plc:… read as an invalid port), so it errors before any ignore rule applies.
+# A regex here can't suppress them; the links.yml "Strip standard.site link tags"
+# step removes those tags from the throwaway build before lychee runs instead.
 
 # Intentionally-broken demo links in posts that document 404 behavior.
 # Pattern matches both raw root-relative form and the file:// form lychee


### PR DESCRIPTION
Addresses #1884 (lychee "Broken links detected" report — 587 errors).

The report splits into three buckets. This PR lands the systematic fix first; the link-rot swaps follow as additional commits.

## 1. Systematic `at://` false positives (125+ errors — the bulk) ✅

Every post emits the spec-required `<link rel="site.standard.document" href="at://did:plc:…">` standard.site verification tag (plus the homepage publication tag). lychee 0.24.2 (the action's pinned default) **can't parse the `at://` scheme** — the colons in `did:plc:…` read as an invalid port — so it throws a hard parse error *before* any `--exclude`, `--scheme`, `--remap`, or `.lycheeignore` rule applies (all of those run post-parse). The old `^at://` ignore line was therefore dead code. This produced 125+ false positives per scheduled run, drowning real link rot.

**Fix:** strip these verification-infrastructure link tags from the throwaway link-check build (after `lint-html`, before lychee). Production output is unaffected — `links.yml` builds its own `dist-astro` and never deploys it. Removed the dead `^at://` rule. Verified site-wide: **0 `at://` errors** remain.

## 2. & 3. Dead microsites + external link rot (archive.org swaps) — follow-up commits

Per maintainer direction: replace genuinely-dead links with contemporaneous web.archive.org snapshots (CDX era-closest, not recent parked captures), unlink where no snapshot exists, and **leave live links alone** (verified — many `ERROR`-status links like bit.ly/Business Insider just block lychee's bot and return 200).

## Separate finding (not in this PR): archived posts 404

`src/pages/[year]/[month]/[day]/[slug].astro` `getStaticPaths` uses `isPublishedPost`, which excludes `archived` posts — so all 28 archived posts 404, even though `PostLayout` renders an `ArchivedPostWarning` banner and plumbs the `archived` prop for them (currently dead code). ~10 archived posts have inbound links from other content. Recommend a one-predicate fix to build archived posts (with the warning) while keeping them out of listings/feed/sitemap. Flagged for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)