### PR TITLE
Revert premature buy-now book CTA to pre-launch teaser

### DIFF
--- a/src/components/BookCta.astro
+++ b/src/components/BookCta.astro
@@ -2,12 +2,10 @@
 /**
  * Book CTA Component
  *
- * Promotes the Open & Async book with a buy link to the book site.
+ * Promotes the Open & Async book with a link to the book site.
  * Supports two variants: inline (for posts) and featured (for homepage).
  * Both quote the marketing site (open-and-async.com): a dark-navy "book
  * object" anchored by the 3D cover mockup, with the lime→pink accent system.
- * Now that the book has launched, both variants sell ("Buy it") rather than
- * capture emails. For the dedicated launch announcement use BookLaunchCta.
  */
 
 import { Image } from 'astro:assets';
@@ -65,17 +63,17 @@ const commitGraphPaths = `
       <div class="flex-1 text-center md:text-left">
         <p class="mb-3">
           <span class="inline-flex items-center gap-1.5 rounded-md bg-brand-900 border border-brand-600 px-3 py-1 font-mono text-[0.7rem] uppercase tracking-widest text-white">
-            <span aria-hidden="true" class="text-accent-400">&gt;</span> Out now
+            <span aria-hidden="true" class="text-accent-400">&gt;</span> Coming {siteConfig.bookLaunch}
           </span>
         </p>
         <p class="text-2xl md:text-3xl font-bold text-white mb-2 leading-tight">
           <Fragment set:html={bookTitleHtml} />
         </p>
         <p class="text-sm md:text-base text-slate-300 mb-5">
-          {siteConfig.bookDescription}. Drawing on a decade at GitHub — out now on Kindle, Apple Books, Kobo &amp; more.
+          {siteConfig.bookDescription}. Drawing on a decade at GitHub — sign up to get notified when it launches.
         </p>
         <span class="oa-cta-btn inline-flex items-center gap-1.5 rounded-lg px-5 py-2.5 text-sm font-semibold text-brand-950 transition-all duration-200 whitespace-nowrap">
-          Buy it — {siteConfig.bookPrice} <span aria-hidden="true" class="motion-safe:group-hover:translate-x-0.5 transition-transform duration-200">→</span>
+          Get notified <span aria-hidden="true" class="motion-safe:group-hover:translate-x-0.5 transition-transform duration-200">→</span>
         </span>
       </div>
     </div>
@@ -96,10 +94,10 @@ const commitGraphPaths = `
       />
       <div>
         <p class="font-mono text-[0.65rem] uppercase tracking-widest text-accent-400 mb-1">
-          <span aria-hidden="true">&gt;</span> Out now
+          <span aria-hidden="true">&gt;</span> Coming {siteConfig.bookLaunch}
         </p>
         <p class="text-sm font-semibold text-white mb-1">
-          Liked this post? It's now a book.
+          Like this post? It's becoming a book.
         </p>
         <a
           href={siteConfig.bookUrl}
@@ -107,7 +105,7 @@ const commitGraphPaths = `
           rel="noopener noreferrer"
           class="inline-flex items-center gap-1.5 text-sm font-semibold text-accent-400 no-underline transition-colors duration-200 before:absolute before:inset-0 before:rounded-xl"
         >
-          Buy Open &amp; Async — {siteConfig.bookPrice} <span aria-hidden="true" class="motion-safe:group-hover:translate-x-0.5 transition-transform duration-200">→</span>
+          Get notified when it launches <span aria-hidden="true" class="motion-safe:group-hover:translate-x-0.5 transition-transform duration-200">→</span>
         </a>
       </div>
     </div>

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,8 +65,10 @@ export const siteConfig = {
   // Find this in your Kit dashboard under Forms → form embed code.
   kitFormId: '9381290',
 
-  // Book — now launched, so the callouts sell ("buy now") rather than capture
-  // emails. bookPrice leads the CTAs; paperback is the secondary option.
+  // Book — pre-launch until bookLaunch. The sitewide BookCta stays in teaser
+  // mode ("Coming …", get-notified) until then; only the gated launch post's
+  // BookLaunchCta uses bookPrice/bookPricePaperback. On launch day, flip BookCta
+  // to buy-now to match the marketing site.
   bookUrl: 'https://open-and-async.com/',
   bookTitle: 'Open & Async',
   bookDescription: 'The collaborative software development playbook for remote and distributed teams',


### PR DESCRIPTION
## Problem

Merging #1891 flipped the **sitewide** `BookCta` (homepage + every post) from teaser to buy-now — **"Out now — Buy it — $9.99 / $29.99 paperback"** — and it is **live in production now**, 13 days before the July 21 launch.

`published: false` gates the launch *post*, but not the always-on `BookCta`, so the flip shipped ungated. Meanwhile **open-and-async.com is still in pre-order**, so the main site currently overstates availability (says "out now / buy it" for a book you can only pre-order).

## Fix

Restore the pre-launch teaser sitewide:

- `BookCta.astro`: "Coming July 21, 2026" + get-notified (was "Out now / Buy it — $9.99")
- `config.ts`: keep `bookPrice`/`bookPricePaperback` (the gated post's `BookLaunchCta` needs them at launch); update the stale "now launched" comment

`npm run check` clean.

## Launch day (July 21)

Do these together:
1. Flip the post `published: false` → true (`src/content/posts/2026-07-21-open-and-async.mdx`)
2. Flip `BookCta` back to buy-now (revert this PR's change / restore the "Out now — Buy it" copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)