### PR TITLE
Bust Astro build cache when the markdown pipeline changes

### DIFF
--- a/.github/workflows/astro-e2e.yml
+++ b/.github/workflows/astro-e2e.yml
@@ -58,9 +58,16 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: node_modules/.astro
-          key: astro-cache-${{ runner.os }}-${{ hashFiles('src/**/*', 'public/**/*', 'astro.config.mjs', 'tsconfig.astro.json', 'package-lock.json') }}
+          # The pipeline fingerprint (remark/rehype plugins, their config wiring, and
+          # deps) is a distinct key segment AND the restore-keys prefix. Astro caches
+          # rendered markdown per content-file digest and reuses it for unchanged files
+          # regardless of plugin code, so a broad `astro-cache-<os>-` restore-key would
+          # resurrect HTML built by an old pipeline (e.g. retired /q/<id> quote links).
+          # Folding the pipeline hash into the prefix busts the cache when rendering
+          # changes, while still reusing it across content-only edits.
+          key: astro-cache-${{ runner.os }}-${{ hashFiles('src/lib/**', 'astro.config.mjs', 'src/content.config.ts', 'package-lock.json') }}-${{ hashFiles('src/**/*', 'public/**/*', 'tsconfig.astro.json') }}
           restore-keys: |
-            astro-cache-${{ runner.os }}-
+            astro-cache-${{ runner.os }}-${{ hashFiles('src/lib/**', 'astro.config.mjs', 'src/content.config.ts', 'package-lock.json') }}-
 
       - name: Build Astro site
         run: npm run build

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -50,9 +50,16 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: node_modules/.astro
-          key: astro-cache-${{ runner.os }}-${{ hashFiles('src/**/*', 'public/**/*', 'astro.config.mjs', 'tsconfig.astro.json', 'package-lock.json') }}
+          # The pipeline fingerprint (remark/rehype plugins, their config wiring, and
+          # deps) is a distinct key segment AND the restore-keys prefix. Astro caches
+          # rendered markdown per content-file digest and reuses it for unchanged files
+          # regardless of plugin code, so a broad `astro-cache-<os>-` restore-key would
+          # resurrect HTML built by an old pipeline (e.g. retired /q/<id> quote links)
+          # and deploy it. Folding the pipeline hash into the prefix busts the cache when
+          # rendering changes, while still reusing it across content-only edits.
+          key: astro-cache-${{ runner.os }}-${{ hashFiles('src/lib/**', 'astro.config.mjs', 'src/content.config.ts', 'package-lock.json') }}-${{ hashFiles('src/**/*', 'public/**/*', 'tsconfig.astro.json') }}
           restore-keys: |
-            astro-cache-${{ runner.os }}-
+            astro-cache-${{ runner.os }}-${{ hashFiles('src/lib/**', 'astro.config.mjs', 'src/content.config.ts', 'package-lock.json') }}-
 
       - name: Build Astro site
         run: npm run build


### PR DESCRIPTION
## Root cause

The failing E2E test — `link-validation.spec.ts:92 › sample blog posts should not have broken internal links` — has failed on **every** `main` push since the `/q/<id>` quote pages were retired. It flags two dead links in the *cathedral-bazaar-management* post: `/q/match-management-to-the-moment/` and `/q/cathedral-bazaar-operating-systems/`.

The source is correct — those posts use inline `:quote[…]{#id}` directives that render `#quote-` anchors, and a **cold build produces zero `/q/` links**. This is CI cache staleness, not content:

- Both workflows cache `node_modules/.astro` (Astro's content layer) with `restore-keys: astro-cache-<os>-`.
- Astro caches *rendered markdown* keyed on each file's content digest and reuses it for unchanged files **regardless of the remark/rehype plugin code**.
- When the quote plugin switched from `/q/` links to `#quote-` anchors, the cathedral post's `.md` never changed — so CI restored the pre-change cache and kept shipping its stale `/q/` HTML. `astro preview` (what E2E runs against) doesn't honor the `/q/* → /posts/` 301 in `_redirects`, so it 404s.

Reproduced the reuse mechanism locally (building with a different plugin than what's cached leaves unchanged content un-re-rendered) and confirmed via the `.astro` data-store cache.

## Fix

Fold a pipeline fingerprint (`src/lib/**`, `astro.config.mjs`, `src/content.config.ts`, `package-lock.json`) into both the cache **key** and the **restore-keys prefix**, in `astro-e2e.yml` *and* `build-and-deploy.yml`. A rendering-pipeline change now busts the cache; content-only edits still reuse it.

The deploy workflow had the identical bug, so prod was serving the degraded `/q/ → /posts/` 301 on every quote share link until an unrelated edit touched those posts — this fixes that path too.

## Verification

- Cold build (`rm -rf node_modules/.astro && npm run build`): 0 `/q/` links, 27 quote posts rendering `#quote-` anchors.
- All 5 `link-validation` tests green against a stable preview server, including the originally-failing one.
- Both workflow YAMLs parse clean.

The new key format can't prefix-match any existing cache, so the first run on each workflow cold-builds automatically; no manual cache purge needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)