### PR TITLE
Note book-cut posts in the BookCta as a marketing hook

### DIFF
--- a/src/components/BookCta.astro
+++ b/src/components/BookCta.astro
@@ -14,9 +14,23 @@ import coverImage from '../../assets/img/open-and-async-cover.webp';
 
 interface Props {
   variant?: 'inline' | 'featured';
+  // Marketing hook for posts that came from the manuscript: 'adapted' (a version
+  // appears in the book) or 'cut' (didn't make the final cut). Swaps the inline
+  // headline; both read true before and after launch, so no staleness at launch.
+  relation?: 'adapted' | 'cut' | undefined;
 }
 
-const { variant = 'inline' } = Astro.props;
+const { variant = 'inline', relation } = Astro.props;
+
+// Explicit, launch-safe headline for the inline variant. Stating the book
+// lineage is itself the marketing win: "adapted" signals depth, "cut" signals
+// there's more where this came from.
+const inlineHeadline =
+  relation === 'adapted'
+    ? 'This post is adapted from the book.'
+    : relation === 'cut'
+      ? "This post didn't make the book's final cut."
+      : "Like this post? It's becoming a book.";
 
 // Colorize the ampersand with the site's signature lime→pink gradient.
 // Consume surrounding spaces so mx-1 controls the total whitespace (natural
@@ -97,7 +111,7 @@ const commitGraphPaths = `
           <span aria-hidden="true">&gt;</span> Coming {siteConfig.bookLaunch}
         </p>
         <p class="text-sm font-semibold text-white mb-1">
-          Like this post? It's becoming a book.
+          {inlineHeadline}
         </p>
         <a
           href={siteConfig.bookUrl}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -56,6 +56,7 @@ const postsCollection = defineCollection({
     // Post metadata
     image: z.string().optional(), // Open Graph image
     hideBookCta: z.boolean().default(false), // Suppress the auto-appended BookCta (e.g. the launch post supplies its own BookLaunchCta)
+    bookRelation: z.enum(['adapted', 'cut']).optional(), // Post came from the manuscript: swaps the BookCta headline ('adapted' from a chapter, or 'cut' from the final book)
 
     // SEO metadata
     sitemap: z.boolean().default(true), // Include in sitemap by default

--- a/src/content/posts/2026-04-06-no-agenda-no-meeting.md
+++ b/src/content/posts/2026-04-06-no-agenda-no-meeting.md
@@ -1,5 +1,6 @@
 ---
 title: No agenda, no meeting
+bookRelation: cut
 description: Announcing noagendanomeeting.net — a single-page site advocating that every meeting deserves an agenda, and most meetings deserve to be a document instead.
 ---
 

--- a/src/content/posts/2026-04-27-one-on-one-playbook.md
+++ b/src/content/posts/2026-04-27-one-on-one-playbook.md
@@ -1,5 +1,6 @@
 ---
 title: "How to one-on-one"
+bookRelation: cut
 description: "Most 1:1s waste your team's only protected synchronous time on status updates. Here's how to run ones worth showing up for."
 tldr: "Stop using 1:1s for status updates. Prep async, focus on career growth, coaching, feedback, and human connection, and protect the time like it matters—because it does."
 ---

--- a/src/content/posts/2026-04-27-the-brag-doc.md
+++ b/src/content/posts/2026-04-27-the-brag-doc.md
@@ -1,5 +1,6 @@
 ---
 title: The brag doc
+bookRelation: cut
 description: "Why you need a running record of your wins—and how to keep one without dying of embarrassment"
 tldr: "Nobody's compiling your stats for you. Keep a ship log of your impact, update it weekly, and use it to fight recency bias, ace self-assessments, and build your promotion case."
 ---

--- a/src/content/posts/2026-06-07-reorgs-happen.md
+++ b/src/content/posts/2026-06-07-reorgs-happen.md
@@ -1,5 +1,6 @@
 ---
 title: Reorgs happen
+bookRelation: cut
 description: "In thirteen years at GitHub I was part of 25 reorgs—almost one every six months. Reorgs are a constant in tech, not a crisis. Here's how to navigate them."
 tldr: "Twenty-five reorgs in thirteen years taught me that reorgs are baseline, not exception. Don't panic, re-onboard yourself, reset with your new manager, and treat the shuffle as a chance to renegotiate your scope. Optimize for what persists: reputation, relationships, and the work itself."
 ---

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -43,6 +43,7 @@ interface Props {
   nextPost?: { title: string; url: string; readingTime?: number } | undefined;
   archived?: boolean;
   hideBookCta?: boolean;
+  bookRelation?: 'adapted' | 'cut';
   robots?: string | undefined;
   postId: string;
   postFilePath?: string | undefined;
@@ -63,6 +64,7 @@ const {
   nextPost,
   archived = false,
   hideBookCta = false,
+  bookRelation,
   robots,
   postId,
   postFilePath,
@@ -141,7 +143,7 @@ const blogPostingSchema = pubDate ? generateBlogPostingSchema({
 
         <ReadingProgress readingTime={readingTime} />
 
-        {!hideBookCta && <BookCta />}
+        {!hideBookCta && <BookCta relation={bookRelation} />}
 
         {pubDate && (
           <div class="mt-12 border-t border-gray-200 dark:border-gray-700 py-5 flex flex-wrap items-center justify-between gap-x-3 gap-y-3 text-sm text-gray-600 dark:text-gray-300" data-pagefind-ignore>

--- a/src/pages/[year]/[month]/[day]/[slug].astro
+++ b/src/pages/[year]/[month]/[day]/[slug].astro
@@ -82,6 +82,7 @@ const nextPost = nextEntry ? { title: nextEntry.data.title, url: getPostUrl(next
   nextPost={nextPost}
   archived={post.data.archived}
   hideBookCta={post.data.hideBookCta}
+  bookRelation={post.data.bookRelation}
   robots={post.data.robots}
   postId={post.id}
   postFilePath={post.filePath}


### PR DESCRIPTION
Posts that were **cut from or adapted from** *Open & Async* now say so explicitly, turning the book's provenance into a soft marketing hook. Rather than hardcoding a prose line in each post (which would go stale at the July 21 launch when the sitewide `BookCta` flips to buy-now), the note is driven through the auto-appended CTA — one source of truth, launch-aware.

## How it works

- New `bookRelation` front-matter field (`'adapted' | 'cut'`), threaded schema → post route → `PostLayout` → `BookCta`.
- `BookCta` swaps its inline headline:
  - `adapted` → "This post is adapted from the book."
  - `cut` → "This post didn't make the book's final cut."
  - default (unset) → unchanged: "Like this post? It's becoming a book."

## Posts marked (all `cut`)

- `reorgs-happen`
- `the-brag-doc`
- `one-on-one-playbook`
- `no-agenda-no-meeting`

The upcoming **work-loudly** post (#1900) is `adapted` and gets its flag on that branch; it renders once this plumbing merges to `main`.

`npm run check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)