### PR TITLE
Reading Dynamic Island: a morphing pill for posts

### DIFF
--- a/e2e/reading-island.spec.ts
+++ b/e2e/reading-island.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * E2E for the reading "Dynamic Island" pill (ReadingIsland.astro).
+ *
+ * The state-selection logic is unit-tested (reading-island-state.test.ts); these
+ * tests assert the DOM wiring end to end: the right face shows for scroll,
+ * selection, and reaching the subscribe card, and the pill stays on-screen.
+ */
+import { test, expect } from '@playwright/test';
+import { waitForPageReady } from './helpers';
+
+const POST = '/2026/06/07/reorgs-happen/';
+
+test.describe('Reading island', () => {
+  test('shows "min left" progress once into the article body', async ({ page }) => {
+    await page.goto(POST);
+    await waitForPageReady(page);
+
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight * 0.4));
+
+    const island = page.locator('#reading-island');
+    await expect.poll(() => island.getAttribute('data-state')).toBe('progress');
+    await expect(page.locator('.reading-island-time')).toHaveText(/\d+ min left/);
+  });
+
+  test('morphs to Share when text is selected, and stays on-screen', async ({ page }) => {
+    await page.goto(POST);
+    await waitForPageReady(page);
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight * 0.4));
+
+    await page.evaluate(() => {
+      const p = document.querySelector('.post-content p')!;
+      const range = document.createRange();
+      range.selectNodeContents(p);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+
+    const island = page.locator('#reading-island');
+    await expect.poll(() => island.getAttribute('data-state')).toBe('share');
+
+    const pill = page.locator('.reading-island-pill');
+    await expect(pill).toBeEnabled();
+    await expect(pill).toHaveAttribute('aria-label', /share/i);
+
+    // The pill must not overflow the viewport (regression: wide face clipped).
+    const fits = await pill.evaluate(
+      (el) => el.getBoundingClientRect().right <= window.innerWidth + 1
+    );
+    expect(fits).toBe(true);
+  });
+
+  test('morphs to the subscribe CTA when the subscribe card is in view', async ({ page }) => {
+    await page.goto(POST);
+    await waitForPageReady(page);
+
+    await page.evaluate(() => {
+      const card = document.querySelector('.subscribe-card')!;
+      const y = card.getBoundingClientRect().top + window.scrollY - window.innerHeight * 0.4;
+      window.scrollTo(0, y);
+    });
+
+    const island = page.locator('#reading-island');
+    await expect.poll(() => island.getAttribute('data-state'), { timeout: 5000 }).toBe('cta');
+    await expect(page.locator('.reading-island-pill')).toHaveAttribute('aria-label', /subscribe/i);
+
+    const fits = await page
+      .locator('.reading-island-pill')
+      .evaluate((el) => el.getBoundingClientRect().right <= window.innerWidth + 1);
+    expect(fits).toBe(true);
+  });
+});

--- a/src/components/ReadingIsland.astro
+++ b/src/components/ReadingIsland.astro
@@ -110,12 +110,17 @@ const { readingTime = 0 } = Astro.props;
     outline-offset: 2px;
   }
 
+  /* width:max-content so each face measures to its natural content width
+   * (the controller reads offsetWidth to resize the pill). Left-anchored and
+   * full-height so all faces overlay in the same spot; the active one shows. */
   .reading-island-face {
     position: absolute;
-    inset: 0;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: max-content;
     display: flex;
     align-items: center;
-    justify-content: center;
     gap: 0.4rem;
     padding: 0 0.9rem;
     white-space: nowrap;

--- a/src/components/ReadingIsland.astro
+++ b/src/components/ReadingIsland.astro
@@ -1,0 +1,175 @@
+---
+/**
+ * ReadingIsland
+ *
+ * A floating "Dynamic Island"-style pill on post pages that morphs its contents
+ * as the reader moves through the article, consolidating three affordances:
+ *
+ *   progress → "N min left" (default while reading)
+ *   share    → share the current text selection (when text is selected)
+ *   cta      → nudge to subscribe (near the end / subscribe card in view)
+ *
+ * The three "faces" are pre-rendered (so icons stay zero-JS via the Icon
+ * component); the controller (reading-island.ts) toggles which face is active,
+ * fills in the time, and fluidly resizes the pill. State selection is a pure
+ * function (reading-island-state.ts); progress comes from the shared
+ * reading-progress-core. Respects prefers-reduced-motion.
+ */
+import Icon from './Icon.astro';
+
+interface Props {
+  readingTime?: number;
+}
+
+const { readingTime = 0 } = Astro.props;
+---
+
+<div id="reading-island" class="reading-island" data-reading-time={readingTime} data-state="hidden" hidden>
+  <button type="button" class="reading-island-pill" aria-hidden="true" tabindex="-1">
+    <span class="reading-island-face" data-face="progress" aria-hidden="true">
+      <Icon name="clock" class="reading-island-icon" />
+      <span class="reading-island-time"></span>
+    </span>
+    <span class="reading-island-face" data-face="share" aria-hidden="true">
+      <Icon name="share-nodes" class="reading-island-icon" />
+      <span class="reading-island-share-label">Share selection</span>
+    </span>
+    <span class="reading-island-face" data-face="cta" aria-hidden="true">
+      <Icon name="envelope" class="reading-island-icon" />
+      Enjoyed this? Subscribe
+    </span>
+  </button>
+  <span class="reading-island-status sr-only" role="status" aria-live="polite"></span>
+</div>
+
+<script>
+  import '../scripts/reading-island';
+</script>
+
+<style is:global>
+  .reading-island {
+    position: fixed;
+    bottom: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 9998;
+    pointer-events: none;
+  }
+
+  @media (min-width: 768px) {
+    .reading-island {
+      left: auto;
+      right: 2rem;
+      transform: none;
+    }
+  }
+
+  .reading-island[hidden] {
+    display: none;
+  }
+
+  .reading-island-pill {
+    position: relative;
+    display: block;
+    height: 2.25rem;
+    width: 8rem; /* replaced by JS with the active face's measured width */
+    margin: 0;
+    padding: 0;
+    border: 1px solid rgb(229 231 235);
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(8px);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    color: rgb(55 65 81);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1;
+    cursor: default;
+    pointer-events: auto;
+    overflow: hidden;
+    transition:
+      width 0.38s cubic-bezier(0.34, 1.4, 0.5, 1),
+      box-shadow 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  .reading-island[data-state='share'] .reading-island-pill,
+  .reading-island[data-state='cta'] .reading-island-pill {
+    cursor: pointer;
+  }
+
+  .reading-island[data-state='share'] .reading-island-pill:hover,
+  .reading-island[data-state='cta'] .reading-island-pill:hover {
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.14);
+    transform: translateY(-1px);
+  }
+
+  .reading-island[data-state='share'] .reading-island-pill:focus-visible,
+  .reading-island[data-state='cta'] .reading-island-pill:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  .reading-island-face {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0 0.9rem;
+    white-space: nowrap;
+    opacity: 0;
+    transform: translateY(0.4rem);
+    transition:
+      opacity 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  .reading-island[data-state='progress'] [data-face='progress'],
+  .reading-island[data-state='share'] [data-face='share'],
+  .reading-island[data-state='cta'] [data-face='cta'] {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .reading-island-icon {
+    width: 0.875rem;
+    height: 0.875rem;
+    flex-shrink: 0;
+  }
+
+  .reading-island .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .reading-island-pill {
+      background: rgba(17, 24, 39, 0.92);
+      border-color: rgb(55 65 81);
+      color: rgb(209 213 219);
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .reading-island-pill,
+    .reading-island-face {
+      transition: none;
+    }
+  }
+
+  @media print {
+    .reading-island {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/ReadingProgress.astro
+++ b/src/components/ReadingProgress.astro
@@ -2,20 +2,14 @@
 /**
  * ReadingProgress
  *
- * Thin progress bar fixed at the very top of the viewport showing how far
- * the reader has scrolled through the *article body* (not the full page —
- * excludes bio, CTAs, footer), with an optional "N min left" label in the
- * bottom-right corner. Only renders on post pages (included in PostLayout).
+ * Thin progress bar fixed at the very top of the viewport showing how far the
+ * reader has scrolled through the *article body* (not the full page — excludes
+ * bio, CTAs, footer). Only renders on post pages (included in PostLayout).
  *
- * Uses requestAnimationFrame-throttled scroll handling. Respects
- * prefers-reduced-motion.
+ * Progress is computed by the shared reading-progress-core (one rAF-throttled
+ * scroll listener for the whole page). The "N min left" affordance now lives in
+ * ReadingIsland. Respects prefers-reduced-motion.
  */
-
-interface Props {
-  readingTime?: number;
-}
-
-const { readingTime = 0 } = Astro.props;
 ---
 
 <div
@@ -26,87 +20,22 @@ const { readingTime = 0 } = Astro.props;
   aria-valuemin="0"
   aria-valuemax="100"
   aria-valuenow="0"
-  data-reading-time={readingTime}
 >
   <div id="reading-progress-bar" class="reading-progress-bar"></div>
 </div>
-{readingTime > 0 && (
-  <div id="reading-progress-label" class="reading-progress-label" aria-hidden="true"></div>
-)}
 
 <script>
-  import { formatTimeRemaining } from '../utils/time-remaining';
+  import { subscribeReadingProgress } from '../scripts/reading-progress-core';
 
-  function initReadingProgress() {
-    const barEl = document.getElementById('reading-progress-bar');
-    const containerEl = document.getElementById('reading-progress');
-    const labelEl = document.getElementById('reading-progress-label');
-    if (!barEl || !containerEl) return;
-
-    const bar = barEl as HTMLElement;
-    const container = containerEl;
-    const bodyEl = document.querySelector('.post-content') as HTMLElement | null;
-    const readingTime = Number(container.dataset.readingTime || 0);
-    let ticking = false;
-    let bodyTop = 0;
-    let scrollRange = 0;
-
-    function cacheBodyMetrics() {
-      if (!bodyEl) {
-        // Fallback: track full page scroll if post body not found.
-        bodyTop = 0;
-        scrollRange = document.documentElement.scrollHeight - window.innerHeight;
-        return;
-      }
-      const rect = bodyEl.getBoundingClientRect();
-      bodyTop = rect.top + window.scrollY;
-      // Range: from when the top of the body reaches the top of the viewport
-      // to when the bottom of the body reaches the bottom of the viewport.
-      scrollRange = Math.max(bodyEl.offsetHeight - window.innerHeight, 1);
-    }
-
-    function updateProgress() {
-      const offset = window.scrollY - bodyTop;
-      const ratio = scrollRange > 0 ? Math.min(Math.max(offset / scrollRange, 0), 1) : 0;
+  const bar = document.getElementById('reading-progress-bar');
+  const container = document.getElementById('reading-progress');
+  if (bar && container) {
+    subscribeReadingProgress((ratio) => {
       const progress = ratio * 100;
       bar.style.width = `${progress}%`;
       container.setAttribute('aria-valuenow', Math.round(progress).toString());
-
-      if (labelEl && readingTime > 0) {
-        const text = formatTimeRemaining(readingTime, ratio);
-        if (text) {
-          labelEl.textContent = text;
-          labelEl.classList.add('visible');
-        } else {
-          labelEl.classList.remove('visible');
-        }
-      }
-
-      ticking = false;
-    }
-
-    function onScroll() {
-      if (!ticking) {
-        requestAnimationFrame(updateProgress);
-        ticking = true;
-      }
-    }
-
-    cacheBodyMetrics();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    window.addEventListener('resize', () => {
-      cacheBodyMetrics();
-      updateProgress();
-    }, { passive: true });
-    // Recompute after images/fonts settle.
-    window.addEventListener('load', () => {
-      cacheBodyMetrics();
-      updateProgress();
     });
-    updateProgress();
   }
-
-  initReadingProgress();
 </script>
 
 <style is:global>
@@ -129,49 +58,14 @@ const { readingTime = 0 } = Astro.props;
     border-radius: 0 1px 1px 0;
   }
 
-  .reading-progress-label {
-    position: fixed;
-    bottom: 5rem;
-    right: 2rem;
-    z-index: 9998;
-    padding: 0.25rem 0.625rem;
-    font-size: 0.75rem;
-    line-height: 1;
-    font-weight: 500;
-    color: rgb(75 85 99);
-    background: rgba(255, 255, 255, 0.92);
-    border: 1px solid rgb(229 231 235);
-    border-radius: 9999px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-    opacity: 0;
-    transform: translateY(4px);
-    transition: opacity 0.2s ease, transform 0.2s ease;
-    pointer-events: none;
-  }
-
-  .reading-progress-label.visible {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .reading-progress-label {
-      color: rgb(209 213 219);
-      background: rgba(17, 24, 39, 0.92);
-      border-color: rgb(55 65 81);
-    }
-  }
-
   @media (prefers-reduced-motion: reduce) {
-    .reading-progress-bar,
-    .reading-progress-label {
+    .reading-progress-bar {
       transition: none;
     }
   }
 
   @media print {
-    .reading-progress,
-    .reading-progress-label {
+    .reading-progress {
       display: none;
     }
   }

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -24,6 +24,7 @@ import TableOfContents from '../components/TableOfContents.astro';
 import TableOfContentsSidebar from '../components/TableOfContentsSidebar.astro';
 import ReadingList from '../components/ReadingList.astro';
 import ReadingProgress from '../components/ReadingProgress.astro';
+import ReadingIsland from '../components/ReadingIsland.astro';
 import KeepReading from '../components/KeepReading.astro';
 import DiscussLinks from '../components/DiscussLinks.astro';
 import SubscribeCta from '../components/SubscribeCta.astro';
@@ -145,7 +146,8 @@ const blogPostingSchema = pubDate ? generateBlogPostingSchema({
 
         <ReadingList posts={curatedPosts} roles={curatedRoles} />
 
-        <ReadingProgress readingTime={readingTime} />
+        <ReadingProgress />
+        <ReadingIsland readingTime={readingTime} />
 
         {!hideBookCta && <BookCta relation={bookRelation} />}
 

--- a/src/scripts/reading-island-state.test.ts
+++ b/src/scripts/reading-island-state.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { selectReadingIslandState } from './reading-island-state';
+
+const base = { ratio: 0.5, hasSelection: false, ctaVisible: false };
+
+describe('selectReadingIslandState', () => {
+  it('shows progress while reading the body', () => {
+    expect(selectReadingIslandState(base)).toBe('progress');
+  });
+
+  it('stays hidden before the reveal threshold', () => {
+    expect(selectReadingIslandState({ ...base, ratio: 0.01 })).toBe('hidden');
+  });
+
+  it('respects a custom reveal threshold', () => {
+    expect(selectReadingIslandState({ ...base, ratio: 0.2, revealAfter: 0.3 })).toBe('hidden');
+    expect(selectReadingIslandState({ ...base, ratio: 0.4, revealAfter: 0.3 })).toBe('progress');
+  });
+
+  it('shows the CTA when the subscribe card is in view', () => {
+    expect(selectReadingIslandState({ ...base, ratio: 0.95, ctaVisible: true })).toBe('cta');
+  });
+
+  it('prioritizes share over the CTA when text is selected', () => {
+    expect(
+      selectReadingIslandState({ ...base, ratio: 0.95, ctaVisible: true, hasSelection: true })
+    ).toBe('share');
+  });
+
+  it('shows share even at the very top (selection is immediate intent)', () => {
+    expect(selectReadingIslandState({ ...base, ratio: 0, hasSelection: true })).toBe('share');
+  });
+
+  it('treats a non-finite ratio as hidden (no selection)', () => {
+    expect(selectReadingIslandState({ ...base, ratio: Number.NaN })).toBe('hidden');
+  });
+});

--- a/src/scripts/reading-island-state.ts
+++ b/src/scripts/reading-island-state.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure state machine for the reading "Dynamic Island" pill.
+ *
+ * The island morphs between a few states as the reader moves through a post.
+ * Keeping the selection logic pure (no DOM) makes the priority ordering easy to
+ * reason about and unit-test; the controller (reading-island.ts) feeds it live
+ * inputs and applies the resulting state to the DOM.
+ *
+ *  - hidden   — before the reader has entered the article body (avoid showing at
+ *               the very top) and after there's nothing useful to offer.
+ *  - progress — default while reading: "N min left".
+ *  - share    — the reader has selected text: offer to share the selection.
+ *  - cta      — near the end / the subscribe card is in view: nudge to subscribe.
+ *
+ * Priority: an active text selection is the most immediate intent, so share
+ * wins; otherwise the end-of-post CTA; otherwise plain progress.
+ */
+export type ReadingIslandState = 'hidden' | 'progress' | 'share' | 'cta';
+
+export interface ReadingIslandInputs {
+  /** Scroll progress through the article body, 0–1. */
+  ratio: number;
+  /** Whether the reader currently has a non-empty selection in the post body. */
+  hasSelection: boolean;
+  /** Whether the subscribe CTA (end of post) is in the viewport. */
+  ctaVisible: boolean;
+  /**
+   * Fraction of the body scrolled past which the island may appear at all.
+   * Below this the island stays hidden so it never shows at the very top.
+   */
+  revealAfter?: number;
+}
+
+export function selectReadingIslandState({
+  ratio,
+  hasSelection,
+  ctaVisible,
+  revealAfter = 0.05,
+}: ReadingIslandInputs): ReadingIslandState {
+  // A selection is immediate intent — surface Share even at the very top.
+  if (hasSelection) return 'share';
+
+  // Don't show plain progress/CTA until the reader is actually into the body.
+  if (!Number.isFinite(ratio) || ratio < revealAfter) return 'hidden';
+
+  if (ctaVisible) return 'cta';
+  return 'progress';
+}

--- a/src/scripts/reading-island.ts
+++ b/src/scripts/reading-island.ts
@@ -1,0 +1,180 @@
+/**
+ * Controller for the reading "Dynamic Island" pill (ReadingIsland.astro).
+ *
+ * Feeds live inputs — scroll progress, text selection, and whether the subscribe
+ * card is in view — into the pure state machine (reading-island-state.ts), then
+ * applies the resulting state to the DOM: toggles the active face, fills in the
+ * time, and fluidly resizes the pill to fit. Reuses the same building blocks as
+ * the rest of the site (formatTimeRemaining, copyToClipboard, the quote-share
+ * share shape, and track) so behavior stays consistent.
+ */
+import { subscribeReadingProgress } from './reading-progress-core';
+import { selectReadingIslandState, type ReadingIslandState } from './reading-island-state';
+import { formatTimeRemaining } from '../utils/time-remaining';
+import { copyToClipboard } from '../utils/copy-to-clipboard';
+import { track } from './track';
+
+/** How long the "copied" confirmation stays visible (ms). */
+const CONFIRM_MS = 2000;
+
+function init(): void {
+  const island = document.getElementById('reading-island');
+  const body = document.querySelector<HTMLElement>('.post-content');
+  if (!island || !body) return;
+
+  const pill = island.querySelector<HTMLButtonElement>('.reading-island-pill');
+  const timeEl = island.querySelector<HTMLElement>('.reading-island-time');
+  const shareLabel = island.querySelector<HTMLElement>('.reading-island-share-label');
+  const status = island.querySelector<HTMLElement>('.reading-island-status');
+  const faces = new Map<ReadingIslandState, HTMLElement>();
+  island.querySelectorAll<HTMLElement>('.reading-island-face').forEach((f) => {
+    faces.set(f.dataset.face as ReadingIslandState, f);
+  });
+  if (!pill || !timeEl || !shareLabel || !status) return;
+
+  const readingTime = Number(island.dataset.readingTime || 0);
+
+  // Live inputs.
+  let ratio = 0;
+  let hasSelection = false;
+  let selectionText = '';
+  let ctaVisible = false;
+  let current: ReadingIslandState | null = null;
+
+  /** Absolute URL of the current post, without any hash. */
+  const postUrl = (): string => `${location.origin}${location.pathname}`;
+
+  function timeLabel(): string {
+    return formatTimeRemaining(readingTime, ratio);
+  }
+
+  function render(next: ReadingIslandState): void {
+    island!.dataset.state = next;
+    island!.toggleAttribute('hidden', next === 'hidden');
+
+    const interactive = next === 'share' || next === 'cta';
+    pill!.disabled = !interactive;
+    pill!.tabIndex = interactive ? 0 : -1;
+    if (next === 'share') pill!.setAttribute('aria-label', 'Share the selected text');
+    else if (next === 'cta') pill!.setAttribute('aria-label', 'Subscribe to get new posts by email');
+    else pill!.removeAttribute('aria-label');
+    pill!.setAttribute('aria-hidden', interactive ? 'false' : 'true');
+
+    // Fluidly resize the pill to the active face's natural width.
+    const face = next !== 'hidden' ? faces.get(next) : undefined;
+    if (face) pill!.style.width = `${face.offsetWidth}px`;
+  }
+
+  function update(): void {
+    if (timeEl) timeEl.textContent = timeLabel();
+
+    let next = selectReadingIslandState({ ratio, hasSelection, ctaVisible });
+    // Nothing useful to show in the progress state without a time estimate.
+    if (next === 'progress' && !timeLabel()) next = 'hidden';
+
+    if (next === current) return;
+    current = next;
+    render(next);
+  }
+
+  function flashCopied(): void {
+    if (!shareLabel || !status) return;
+    const original = shareLabel.textContent;
+    shareLabel.textContent = 'Copied';
+    status.textContent = 'Link to selection copied to clipboard';
+    if (current === 'share') pill!.style.width = `${faces.get('share')!.offsetWidth}px`;
+    window.setTimeout(() => {
+      shareLabel.textContent = original;
+      status.textContent = '';
+      if (current === 'share') pill!.style.width = `${faces.get('share')!.offsetWidth}px`;
+    }, CONFIRM_MS);
+  }
+
+  async function share(): Promise<void> {
+    const url = postUrl();
+    const text = selectionText;
+    if (!text) return;
+
+    // Native share sheet — the true one-tap path, best on mobile.
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: document.title, text, url });
+        track('island-share');
+        return;
+      } catch (err) {
+        // User dismissed the sheet — do nothing. Only fall back on real errors.
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+      }
+    }
+
+    if (await copyToClipboard(`${text} — ${url}`)) {
+      flashCopied();
+      track('island-share');
+    }
+  }
+
+  function goToSubscribe(): void {
+    const card = document.querySelector<HTMLElement>('.subscribe-card');
+    if (!card) return;
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    card.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'center' });
+    const email = card.querySelector<HTMLInputElement>('input[type="email"]');
+    if (email) window.setTimeout(() => email.focus({ preventScroll: true }), reduce ? 0 : 400);
+    track('island-subscribe-cta');
+  }
+
+  // Share via pointerdown so preventDefault keeps the text selection intact
+  // (a plain click would collapse it before the handler runs).
+  pill.addEventListener('pointerdown', (event) => {
+    if (current === 'share') {
+      event.preventDefault();
+      void share();
+    }
+  });
+  pill.addEventListener('click', () => {
+    if (current === 'cta') goToSubscribe();
+  });
+
+  // Inputs → state.
+  subscribeReadingProgress((r) => {
+    ratio = r;
+    update();
+  });
+
+  document.addEventListener('selectionchange', () => {
+    const sel = window.getSelection();
+    const text = sel?.toString().trim() ?? '';
+    const within =
+      !!sel &&
+      sel.rangeCount > 0 &&
+      !!sel.anchorNode &&
+      !!sel.focusNode &&
+      body!.contains(sel.anchorNode) &&
+      body!.contains(sel.focusNode);
+    const next = text.length > 0 && within;
+    if (next) selectionText = text;
+    if (next !== hasSelection) {
+      hasSelection = next;
+      update();
+    }
+  });
+
+  const card = document.querySelector('.subscribe-card');
+  if (card && 'IntersectionObserver' in window) {
+    new IntersectionObserver(
+      (entries) => {
+        ctaVisible = entries.some((e) => e.isIntersecting);
+        update();
+      },
+      { rootMargin: '0px 0px -20% 0px' }
+    ).observe(card);
+  }
+
+  update();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/src/scripts/reading-progress-core.ts
+++ b/src/scripts/reading-progress-core.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared reading-progress tracker.
+ *
+ * A single rAF-throttled scroll listener computes how far the reader has moved
+ * through the article body (`.post-content`) as a ratio in [0, 1], and notifies
+ * every subscriber. Both the top progress bar (ReadingProgress) and the reading
+ * island subscribe to this one source, so there's exactly one scroll listener
+ * and one layout read per frame — better for INP than each feature tracking
+ * scroll independently.
+ *
+ * The ratio matches the original ReadingProgress behavior: 0 when the top of the
+ * body reaches the top of the viewport, 1 when its bottom reaches the bottom.
+ */
+type ProgressCallback = (ratio: number) => void;
+
+const subscribers = new Set<ProgressCallback>();
+let initialized = false;
+let ticking = false;
+let bodyTop = 0;
+let scrollRange = 0;
+let lastRatio = 0;
+
+function cacheBodyMetrics(): void {
+  const body = document.querySelector<HTMLElement>('.post-content');
+  if (!body) {
+    // Fallback: track full-page scroll if the post body isn't present.
+    bodyTop = 0;
+    scrollRange = Math.max(document.documentElement.scrollHeight - window.innerHeight, 1);
+    return;
+  }
+  const rect = body.getBoundingClientRect();
+  bodyTop = rect.top + window.scrollY;
+  scrollRange = Math.max(body.offsetHeight - window.innerHeight, 1);
+}
+
+function computeRatio(): number {
+  const offset = window.scrollY - bodyTop;
+  return scrollRange > 0 ? Math.min(Math.max(offset / scrollRange, 0), 1) : 0;
+}
+
+function notify(): void {
+  lastRatio = computeRatio();
+  for (const cb of subscribers) cb(lastRatio);
+  ticking = false;
+}
+
+function onScroll(): void {
+  if (!ticking) {
+    requestAnimationFrame(notify);
+    ticking = true;
+  }
+}
+
+function ensureInitialized(): void {
+  if (initialized) return;
+  initialized = true;
+  cacheBodyMetrics();
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener(
+    'resize',
+    () => {
+      cacheBodyMetrics();
+      notify();
+    },
+    { passive: true }
+  );
+  // Recompute once images/fonts have settled and shifted the layout.
+  window.addEventListener('load', () => {
+    cacheBodyMetrics();
+    notify();
+  });
+}
+
+/**
+ * Subscribe to reading-progress updates. The callback fires immediately with the
+ * current ratio, then on every throttled scroll/resize. Returns an unsubscribe
+ * function.
+ */
+export function subscribeReadingProgress(callback: ProgressCallback): () => void {
+  ensureInitialized();
+  subscribers.add(callback);
+  callback(lastRatio);
+  return () => subscribers.delete(callback);
+}


### PR DESCRIPTION
## What

A vanilla, zero-framework "Dynamic Island"-style pill on post pages that morphs between three states as you read, consolidating three existing affordances into one delightful element:

- **progress** — "N min left" (bottom-right on desktop, bottom-center on mobile)
- **share** — appears when you select text in the post body; native share sheet with clipboard fallback (reuses the `quote-share` pattern)
- **cta** — "Enjoyed this? Subscribe" when the subscribe card scrolls into view; scrolls to and focuses the existing subscribe form

## How

- `src/scripts/reading-island-state.ts` — pure state machine (priority: share > cta > progress), fully unit-tested
- `src/scripts/reading-progress-core.ts` — one shared rAF-throttled scroll listener; `ReadingProgress` is refactored to bar-only and subscribes to the same source (no duplicate scroll work, better INP)
- `src/components/ReadingIsland.astro` + `src/scripts/reading-island.ts` — pre-rendered icon "faces" (icons stay zero-JS via the Icon component), CSS-transition morph, reuses `formatTimeRemaining` / `copyToClipboard` / `track`
- Wired into `PostLayout`; the "N min left" affordance moves from `ReadingProgress` to the island

### Design notes
- **CSS transitions, not the same-document View Transitions API** — `startViewTransition` snapshots the whole article on every state change, wasteful for a persistent widget that updates as you read. CSS transitions give the fluid resize cheaply.
- Fixed a width bug found during verification: faces were `position:absolute; inset:0`, so measuring `offsetWidth` returned the pill's width, not the face's — the wider CTA face clipped. Faces now use `width:max-content` so the pill fluidly resizes to fit.

## Verification
- `astro check` — 0 errors
- Unit: 7 tests for the state machine
- E2E (`e2e/reading-island.spec.ts`): progress / share / cta states + on-screen-fit regression guard
- Build green; all three states walked visually in a real browser (light + dark)

## Status
Draft-quality but complete and tested. Not yet merged — it's a visible production UI change, so opening for review before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)