### PR TITLE
[enhance] Open and Async: the remote-work playbook is out

### DIFF
--- a/src/content/posts/2026-07-21-open-and-async.mdx
+++ b/src/content/posts/2026-07-21-open-and-async.mdx
@@ -9,7 +9,7 @@ published: true
 hideBookCta: true
 ---
 
-Most companies didn't go remote. They shipped everyone a laptop, bolted Zoom onto the same approval chains, and called it a day. That wasn't remote work—it was office work in sweatpants: the same meetings, the same status theater, the same "quick syncs," just piped through a webcam.
+Most companies didn't go remote. They shipped everyone a laptop, bolted Zoom onto the same approval chains, and called it a day. :quote[That wasn't remote work—it was office work in sweatpants: the same meetings, the same status theater, the same "quick syncs," just piped through a webcam.]{#q-that-wasnt-remote-workit-was}
 
 :quote[Working from home ≠ working remotely.]{#work-from-home-not-remote} There's a world of difference between being forced out of the office and intentionally building a distributed, async culture. That difference is what *Open and Async* is about—and as of today, you can [read it](https://open-and-async.com/?utm_source=benbalter-launch-post).
 
@@ -19,7 +19,7 @@ If you've spent any time on this blog, the argument will feel familiar—the boo
 
 ## What separates teams that thrive
 
-More than a decade of remote-first work at GitHub made one thing clear: the tooling was never what separated the teams that thrived from the ones that just survived. Companies would adopt those workflows wholesale—add issues and pull requests on top of a hierarchy-driven approval process—and wonder why nothing changed. Tools: right. Bottlenecks: intact. The result was Zoom fatigue plus all the old dysfunction, now faster.
+More than a decade of remote-first work at [GitHub made one thing clear](/2026/03/04/thirteen-years-at-github/): the tooling was never what separated the teams that thrived from the ones that just survived. Companies would adopt those workflows wholesale—add issues and pull requests on top of a hierarchy-driven approval process—and wonder why nothing changed. Tools: right. Bottlenecks: intact. The result was Zoom fatigue plus all the old dysfunction, now faster.
 
 The teams that pulled ahead did something different. They gave every decision [a URL](/2015/11/12/why-urls/) so context survived reorgs and departures. They treated meetings as escalation, not default. They [worked loudly](/2022/02/16/leaders-show-their-work/) so impact was visible without anyone performing busyness. None of it was intuition—it was a set of repeatable practices, and *Open and Async* is those practices, written down so you can put them to work.
 
@@ -34,7 +34,7 @@ Two audiences, both in remote and distributed work:
 
 A few of the things you'll learn how to do:
 
-- Treat meetings as a point of escalation, not the default—and reclaim the hours you're losing to "quick syncs."
+- [Treat meetings as a point of escalation, not the default](/2023/04/20/meetings-are-a-point-of-escalation/)—and reclaim the hours you're losing to "quick syncs."
 - Give every decision a URL so context survives reorgs, departures, and Slack purges.
 - Run 1:1s, weekly reports, and career conversations that aren't a tax on everyone's time.
 - Lead—whether or not you have direct reports—by showing your work.


### PR DESCRIPTION
> ⚠️ **AI-assisted enhancement — draft for review.**

Applies suggestions from the archive audits to a top (popular/recent) post. In-place wraps only; the argument and voice are unchanged.

### Internal links added
- **“GitHub made one thing clear”** → `/2026/03/04/thirteen-years-at-github/`
- **“Treat meetings as a point of escalation, not the default”** → `/2023/04/20/meetings-are-a-point-of-escalation/`

### Pull quote (\`:quote\` directive)
- Wrapped in place: “That wasn't remote work—it was office work in sweatpants: the same meetings, the same status theater, the same "quick syncs," just piped through a webcam.”

Anchors + quote text are verbatim-verified against the post. Source: `audit/` + `engage/` (script/foundry-interlinks.ts, foundry-engagement.ts).

---
🤖 Applied with [Claude Code](https://claude.com/claude-code)