### PR TITLE
vale-ai-tells: caveat that AJ's 16x drift signal is animacy-inflated

### DIFF
--- a/.vale-ai-tells.ini
+++ b/.vale-ai-tells.ini
@@ -83,3 +83,17 @@ ai-tells.WrapUpHeadings = NO          # "Putting it all together"
 #   FigurativeIdioms              0.03 -> 0.36
 # NB: a flat 2010-2022 baseline mislabels the last two as house style (they were
 # early-2010s habits); only the era-trend reveals them as genuine 2026 drift.
+#
+# CAVEATS from a 2026-08 re-analysis (same instrument run on the Open & Async
+# book, with finer per-era buckets 2010-13 / 14-16 / 17-18 / 19-21):
+# • AnthropomorphicJustification's 16x is INFLATED by subject animacy. The rule
+#   fires on human/collective subjects ("the people doing the work", "deserve
+#   credit", "the team earns") — not anthropomorphism at all — mixed in with the
+#   real inanimate tell ("the spec pays for itself"). On the book, splitting the
+#   matches by subject cut it from 6.7x whole-rule to ~2.4x on the inanimate
+#   subset. Re-measure the 16x here on the inanimate-subject subset before
+#   trusting it as the top signal — the human-subject share is padding it.
+# • FigurativeFalls / FigurativeIdioms confirmed as revived early-2010s habits:
+#   the full decade shows ~0.11/1k in 2010-13 (HIGHER than 2026), fading to 0 by
+#   2017. The four per-era buckets make the "early habit vs novel drift" call
+#   explicit, so prefer them over the 2019-22-vs-2026 two-window split next time.


### PR DESCRIPTION
Docs-only note in the advisory `.vale-ai-tells.ini` — no rule behavior changes.

A 2026-08 re-analysis (same `vale-ai-tells` instrument, run on the *Open and Async* book with finer per-era baseline buckets: 2010-13 / 14-16 / 17-18 / 19-21) turned up two things worth recording against this config's calibration:

1. **The kept-ON top drift signal, `AnthropomorphicJustification` (16×), is inflated by subject animacy.** The rule fires on human/collective subjects ("the people **doing the work**", "**deserve credit**", "the team **earns**") — not anthropomorphism at all — mixed in with the genuine inanimate tell ("the spec **pays for itself**"). On the book, splitting the matches by subject cut it from 6.7× whole-rule to ~2.4× on the inanimate-only subset. The note recommends re-measuring the 16× on the inanimate subset before trusting it as the headline signal.
2. **`FigurativeFalls` / `FigurativeIdioms` confirmed as revived early-2010s habits** — the full decade shows ~0.11/1k in 2010-13 (higher than 2026), fading to 0 by 2017. Corroborates this config's existing NB, and suggests preferring the four per-era buckets over the 2019-22-vs-2026 split for future calibration.

Nothing filed upstream to `tbhb/vale-ai-tells` — the one package-level FP I hit (`AnthropomorphicCognition` "a platform and want") is already handled here via the existing disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)