### PR TITLE
Add em-dash disclaimer to fine print page

### DIFF
--- a/src/pages/fine-print.astro
+++ b/src/pages/fine-print.astro
@@ -61,6 +61,18 @@ const description =
           </div>
         </div>
       </div>
+
+      <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <div class="flex items-start gap-3">
+          <span class="text-xl shrink-0 mt-0.5" aria-hidden="true">➖</span>
+          <div>
+            <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1.5">Em dashes before they were (un)cool</h2>
+            <p class="text-sm text-gray-600 dark:text-gray-300 leading-relaxed m-0">
+              I used em dashes before they were (un)cool—my favorite piece of punctuation, not proof a robot wrote this. They run through <a href="/2011/01/04/the-files-in-the-computer/" class="text-primary dark:text-primary-300 hover:text-primary-700 dark:hover:text-primary-200 underline">my very first posts in 2011</a> and <a href="/2014/03/31/word-versus-markdown-more-than-mere-semantics/" class="text-primary dark:text-primary-300 hover:text-primary-700 dark:hover:text-primary-200 underline">all the way through</a>, years before a language model made them suspicious.
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
 
     {/* Licensing Section */}


### PR DESCRIPTION
## What

Adds a card to the [fine print](/fine-print/) page: **"Em dashes before they were (un)cool."**

Em dashes have become a popular "AI tell." This card stakes the claim that I've been overusing them since long before LLMs existed, with links to em-dash-laden posts from **2011** (my first year blogging) and **2014** as evidence.

## Why

The em dash is a favorite piece of punctuation, not proof a robot wrote the post. Every year from 2011 onward has posts using them (12 in 2011, 21 in 2014). Fun fact that motivated this: running Fast-DetectGPT over the blog, the machine-text signal tracks *abstraction vs. concreteness*, not punctuation — em dashes are a red herring.

## Notes

- New card matches the existing "Oxford comma enthusiast" card's markup/styling.
- `astro check` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)