### PR TITLE
Draft: reduce AI-cadence tells in thirteen-years book intro

### DIFF
--- a/src/content/posts/2026-03-04-thirteen-years-at-github.mdx
+++ b/src/content/posts/2026-03-04-thirteen-years-at-github.mdx
@@ -33,7 +33,7 @@ The choice of Markdown wasn't arbitrary—it uses simple characters you already 
 
 ## A hub, not a headquarters
 
-GitHub had a physical office in San Francisco, but it was more hub than requirement. The office served as a space for meetups, events, and coworking rather than a mandatory 9-to-5 workspace. Hubbers (GitHub employees) were free to work whenever and wherever they were most productive—whether at 3 AM or as digital nomads. This flexibility stood in stark contrast to the traditional office culture of the time.
+GitHub had a physical office in San Francisco, but it was more hub than requirement. The office served as a space for meetups, events, and coworking rather than a mandatory 9-to-5 workspace. Hubbers (GitHub employees) were free to work whenever and wherever they were most productive—whether at 3 AM or as digital nomads.
 
 Despite being remote, GitHub valued in-person interactions. The company hosted an annual "summit" where all employees gathered for a week of talks and coworking, as well as smaller team "mini-summits" for planning and relationship-building. Even GitHub HQ was optimized for remote work, featuring open "cafés" for serendipitous interactions and advanced streaming setups for remote participation in all-hands meetings.
 
@@ -41,11 +41,11 @@ Early on, GitHub had "Hack Houses" where cross-functional teams would meet up in
 
 ## Intentionality over proximity
 
-The physical space strategy reflected a deeper truth about remote work: what happens by accident in an office must be designed deliberately when distributed. You can't rely on overhearing a conversation that sparks an idea or bumping into someone at the coffee machine who has exactly the context you need. These moments can still happen—they just require intentional creation rather than convenient proximity.
+The physical space strategy reflected a deeper truth about remote work: what happens by accident in an office must be designed deliberately when distributed. You can't rely on overhearing a conversation that sparks an idea or bumping into someone at the coffee machine who has exactly the context you need. They still happen remotely—but someone has to decide to make them happen.
 
-Remote teams often worry about losing the "water cooler" moments—those unplanned hallway conversations that spark unexpected ideas. Create digital equivalents: optional social channels, virtual coffee roulettes, or open-ended team threads. The serendipity doesn't have to disappear; it just needs to be intentionally designed rather than left to physical proximity.
+Remote teams often worry about losing the "water cooler" moments—those unplanned hallway conversations that spark unexpected ideas. Create digital equivalents: optional social channels, virtual coffee roulettes, or open-ended team threads. You don't lose the serendipity. You just have to put it on the calendar.
 
-You'd think remote work would weaken company culture. The opposite was true. Remote work forced us to be intentional about communication, documentation, decision-making, and relationship-building. This intentionality strengthened GitHub's culture, enabling it to scale from a small startup to a large company without losing its unique identity, even after its acquisition by Microsoft.
+Remote work should have weakened our culture. Instead it strengthened it. Distance forced us to be intentional about communication, documentation, decision-making, and relationship-building—the habits that let GitHub scale from a small startup to a large company without losing its identity, even after the acquisition by Microsoft.
 
 ## The pursuit of an ideal
 
@@ -53,9 +53,9 @@ Over the years, GitHub practiced many of these principles—imperfectly and not 
 
 ## What thirteen years taught me
 
-The patterns that emerged from a decade-plus of distributed experimentation—working in the open, defaulting to async, documenting decisions, making work visible—aren't just GitHub quirks. They're repeatable practices that any team can adopt, regardless of industry or company size.
+The patterns that emerged from a decade-plus of distributed experimentation—working in the open, defaulting to async, documenting decisions, making work visible—weren't GitHub quirks. Any team can adopt them, in any industry, at any size.
 
-GitHub's remote work evolution shows that distributed collaboration isn't just possible—it can be a competitive advantage. But success requires more than tools and good intentions. It requires a fundamental shift in how we think about work, communication, and collaboration. If you're leading a distributed team, you have to invest in codifying practices, building shared context, and maintaining the cultural elements that made remote work successful when you were smaller. :quote[What happened organically at 50 people requires deliberate effort at 500.]{#organic-at-50-deliberate-at-500} If you're an individual contributor, the practices that work at scale are exactly the habits worth building now—clear documentation, async-first communication, transparent collaboration. These remote work skills are transferable to any organization and compound over time.
+GitHub is proof that distributed collaboration can be a competitive advantage. Getting there takes more than tools—it takes a real shift in how a team thinks about work, communication, and collaboration. If you're leading a distributed team, you have to invest in codifying practices, building shared context, and maintaining the cultural elements that made remote work successful when you were smaller. :quote[What happened organically at 50 people requires deliberate effort at 500.]{#organic-at-50-deliberate-at-500} If you're an individual contributor, the practices that work at scale are exactly the habits worth building now—clear documentation, async-first communication, transparent collaboration. These remote work skills are transferable to any organization and compound over time.
 
 <aside class="my-6 rounded border-l-4 border-blue-500 bg-blue-50 p-4 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200" role="note">
 


### PR DESCRIPTION
**Draft for review — do not merge as-is.** Conservative pass on the sections Fast-DetectGPT (Llama-3-8B) flagged as most machine-like. This is copyright-reserved *book-intro* material, so I only cut generic filler and antithesis tells and added specificity where I could **without inventing biography**.

## Section scores (Llama-3, before → after)
| section | before | after |
|---|---:|---:|
| What thirteen years taught me | 66% | **36%** |
| Intentionality over proximity | 62% | **45%** |
| A hub, not a headquarters | 93% | 85% |

## What changed
- Dropped "The opposite was true", "isn't just X—Y", "aren't just X. They're Y" antithesis tells.
- Cut "This flexibility stood in stark contrast to the traditional office culture of the time" (generic filler).
- Tightened the repeated "serendipity must be intentionally designed" point into "You don't lose the serendipity. You just have to put it on the calendar."

## Note on "A hub, not a headquarters" (still 85%)
Left it essentially as-is. It's already concrete (Hack Houses, Destinations, cafés) yet scores high — a useful reminder that concreteness lowers the signal on average but isn't a guaranteed lever. Hacking a genuinely-concrete section to move a noisy number wasn't worth it.

## Caveat
Whole-post % is a length artifact (criterion grows ~√N); section scores are the real signal. See #1954 for the full method writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)