### PR TITLE
Lint editor/tooling JSONC configs with json/jsonc

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,4 +40,11 @@ export default tseslint.config(
     language: 'json/json',
     ...json.configs.recommended,
   },
+  // JSONC files (JSON with comments) — editor/tooling configs
+  {
+    files: ['.vscode/**/*.json', '.devcontainer/**/*.json'],
+    plugins: {json},
+    language: 'json/jsonc',
+    ...json.configs.recommended,
+  },
 );


### PR DESCRIPTION
## Problem

CI `lint-json` fails on any PR:

```
.devcontainer/devcontainer.json
  31:9  error  Parsing error: Unexpected character '/' found
.vscode/settings.json
  2:3  error  Parsing error: Unexpected character '/' found
```

## Cause

The LTeX+ integration (5f7da565) added `.vscode/settings.json` and `.devcontainer/devcontainer.json`, both of which contain comments (JSONC). The eslint flat config linted every `**/*.json` with the strict `json/json` language, which rejects comments.

## Fix

Add a `json/jsonc` config block scoped to `.vscode/**/*.json` and `.devcontainer/**/*.json` so those editor/tooling configs are parsed as JSON-with-comments. All other JSON stays strict.

`npm run lint-json` now exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)