### PR TITLE
Email: degrade web-only media to email-safe HTML for Kit broadcasts

### DIFF
--- a/script/email-broadcast.mjs
+++ b/script/email-broadcast.mjs
@@ -37,6 +37,7 @@ import { rehypeBootstrapTables } from '../src/lib/rehype-bootstrap-tables.ts';
 import { rehypeFigure } from '../src/lib/rehype-figure.ts';
 import { rehypeImageLoading } from '../src/lib/rehype-image-loading.ts';
 import { rehypeEmailQuotePlain } from '../src/lib/rehype-email-quote-plain.ts';
+import { rehypeEmailMediaFallback } from '../src/lib/rehype-email-media-fallback.ts';
 
 const KIT_API_URL = 'https://api.kit.com/v4/broadcasts';
 const SITE_URL = process.env.SITE_URL || 'https://ben.balter.com';
@@ -53,6 +54,10 @@ const emailRehypePlugins = [
   rehypeBootstrapTables,
   rehypeFigure,
   rehypeImageLoading,
+  // Degrade web-only media (<style>, <video>, <audio>) to email-safe fallbacks.
+  // Runs after rehypeRaw so the raw HTML is real hast by now. Without this, Kit
+  // rejects the whole broadcast with a generic 422 and the email never sends.
+  [rehypeEmailMediaFallback, { siteUrl: SITE_URL }],
   // Flatten the web-only :quote share affordance to plain highlighted text. Its
   // inline share-icon SVG has no width/height and is CSS-sized on the web; email
   // clients drop that CSS, so it otherwise renders as a giant graphic.

--- a/src/lib/rehype-email-media-fallback.test.ts
+++ b/src/lib/rehype-email-media-fallback.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for rehype-email-media-fallback plugin
+ *
+ * Verifies that web-only media (<style>, <video>, <audio>) is degraded to
+ * email-safe fallbacks with absolute asset URLs, so Kit accepts the broadcast.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import rehypeRaw from 'rehype-raw';
+import rehypeStringify from 'rehype-stringify';
+import { rehypeEmailMediaFallback } from './rehype-email-media-fallback';
+
+const SITE = 'https://ben.balter.com';
+
+// Mirror the real email pipeline: raw HTML in markdown → hast (rehypeRaw) → plugin.
+function render(markdown: string, siteUrl = SITE) {
+  return unified()
+    .use(remarkParse)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeEmailMediaFallback, { siteUrl })
+    .use(rehypeStringify)
+    .process(markdown)
+    .then(String);
+}
+
+describe('rehypeEmailMediaFallback', () => {
+  it('drops <style> blocks entirely', async () => {
+    const html = await render(`<style>.x { color: red }</style>\n\nHi`);
+    expect(html).not.toContain('<style');
+    expect(html).not.toContain('color: red');
+  });
+
+  it('replaces <video> with its poster image linking to the mp4 source', async () => {
+    const html = await render(
+      `<video poster="/video/x.jpg" aria-label="A cat"><source src="/video/x.webm" type="video/webm" /><source src="/video/x.mp4" type="video/mp4" /></video>`
+    );
+    expect(html).not.toContain('<video');
+    expect(html).not.toContain('<source');
+    expect(html).toContain(`<img src="${SITE}/video/x.jpg"`);
+    expect(html).toContain(`alt="A cat"`);
+    expect(html).toContain(`href="${SITE}/video/x.mp4"`);
+  });
+
+  it('replaces a poster-less <video> with a "▶ label" link', async () => {
+    const html = await render(
+      `<video aria-label="The clip"><source src="/video/y.mp4" type="video/mp4" /></video>`
+    );
+    expect(html).not.toContain('<video');
+    expect(html).toContain(`href="${SITE}/video/y.mp4"`);
+    expect(html).toContain('▶ The clip');
+  });
+
+  it('replaces <audio> with a "🔊 label" link to the mp3', async () => {
+    const html = await render(
+      `<audio controls aria-label="Sample line"><source src="/audio/z.mp3" type="audio/mpeg" /></audio>`
+    );
+    expect(html).not.toContain('<audio');
+    expect(html).not.toContain('<source');
+    expect(html).toContain(`href="${SITE}/audio/z.mp3"`);
+    expect(html).toContain('🔊 Sample line');
+  });
+
+  it('leaves already-absolute URLs untouched', async () => {
+    const html = await render(
+      `<audio aria-label="X"><source src="https://cdn.example.com/z.mp3" type="audio/mpeg" /></audio>`
+    );
+    expect(html).toContain('href="https://cdn.example.com/z.mp3"');
+    expect(html).not.toContain(`${SITE}/https`);
+  });
+
+  it('strips a trailing slash on siteUrl when absolutizing', async () => {
+    const html = await render(
+      `<audio aria-label="X"><source src="/audio/z.mp3" type="audio/mpeg" /></audio>`,
+      'https://ben.balter.com/'
+    );
+    expect(html).toContain(`href="${SITE}/audio/z.mp3"`);
+    expect(html).not.toContain('.com//audio');
+  });
+
+  it('leaves ordinary content alone', async () => {
+    const html = await render(`A paragraph with a [link](/foo) and *emphasis*.`);
+    expect(html).toContain('<p>');
+    expect(html).toContain('href="/foo"');
+    expect(html).toContain('<em>emphasis</em>');
+  });
+});

--- a/src/lib/rehype-email-media-fallback.ts
+++ b/src/lib/rehype-email-media-fallback.ts
@@ -1,0 +1,116 @@
+/**
+ * Rehype plugin (email only) — degrade web-only media to email-safe fallbacks.
+ *
+ * Posts can embed `<style>` blocks, autoplaying `<video>` GIF-replacements, and
+ * `<audio>` players. None of that survives an inbox: email clients strip
+ * `<style>`, don't play inline `<video>`/`<audio>`, and Kit's broadcast API
+ * flat-out rejects a payload containing them with a generic 422 ("There has been
+ * an error saving your changes"), so the broadcast never sends at all.
+ *
+ * For email we therefore:
+ *   - drop `<style>` elements entirely,
+ *   - replace each `<video>` with its poster image (if any) linking to the
+ *     playable source, or a plain "▶ label" link when there's no poster,
+ *   - replace each `<audio>` with a "🔊 label" link to the audio file.
+ *
+ * All asset URLs are absolutized against `siteUrl` because the email pipeline
+ * deliberately omits relative-URL rewriting, so `/video/…` and `/audio/…` paths
+ * would otherwise be unresolvable in an inbox. Web rendering is untouched — this
+ * runs only in the email pipeline's rehype list.
+ */
+
+import { visit, SKIP } from 'unist-util-visit';
+import type { VisitorResult } from 'unist-util-visit';
+import type { Root, Element, ElementContent } from 'hast';
+
+interface Options {
+  /** Absolute base URL for the site, e.g. "https://ben.balter.com" (no trailing slash needed). */
+  siteUrl?: string;
+}
+
+/** Read a string property, tolerating hast's aria-label → ariaLabel normalization. */
+function stringProp(node: Element, ...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = node.properties?.[name];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return undefined;
+}
+
+/** Absolutize a root-relative URL against siteUrl; leave absolute URLs alone. */
+function absolutize(url: string | undefined, siteUrl: string): string | undefined {
+  if (!url) return undefined;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url) || url.startsWith('//')) return url;
+  if (url.startsWith('/')) return `${siteUrl.replace(/\/$/, '')}${url}`;
+  return url;
+}
+
+/** Collect `<source>` children as {src, type} pairs. */
+function sources(node: Element): { src: string | undefined; type: string | undefined }[] {
+  return node.children
+    .filter((c): c is Element => c.type === 'element' && c.tagName === 'source')
+    .map((s) => ({ src: stringProp(s, 'src'), type: stringProp(s, 'type') }));
+}
+
+/** Pick the most email-friendly playable source (mp4 for video, mpeg for audio). */
+function preferredSource(node: Element, preferType: RegExp): string | undefined {
+  const list = sources(node);
+  const preferred = list.find((s) => s.type && preferType.test(s.type) && s.src);
+  return (preferred?.src ?? list.find((s) => s.src)?.src) || stringProp(node, 'src');
+}
+
+/** Build an <a href=…>children</a> element. */
+function link(href: string, children: ElementContent[]): Element {
+  return {
+    type: 'element',
+    tagName: 'a',
+    properties: { href, target: '_blank', rel: ['noopener', 'noreferrer'] },
+    children,
+  };
+}
+
+export function rehypeEmailMediaFallback(options: Options = {}) {
+  const siteUrl = options.siteUrl || 'https://ben.balter.com';
+
+  return (tree: Root) => {
+    visit(tree, 'element', (node: Element, index, parent): VisitorResult => {
+      if (!parent || index === undefined) return;
+
+      // Drop <style> blocks — email clients strip them and Kit rejects them.
+      if (node.tagName === 'style') {
+        parent.children.splice(index, 1);
+        return [SKIP, index];
+      }
+
+      if (node.tagName === 'video') {
+        const label = stringProp(node, 'ariaLabel', 'aria-label', 'title') || 'Watch the clip';
+        const href =
+          absolutize(preferredSource(node, /mp4/i), siteUrl) ||
+          absolutize(stringProp(node, 'poster'), siteUrl);
+        const poster = absolutize(stringProp(node, 'poster'), siteUrl);
+
+        let replacement: Element;
+        if (poster) {
+          const img: Element = {
+            type: 'element',
+            tagName: 'img',
+            properties: { src: poster, alt: label, style: 'max-width:100%;height:auto;border-radius:.5rem' },
+            children: [],
+          };
+          replacement = href ? link(href, [img]) : img;
+        } else {
+          replacement = link(href || '#', [{ type: 'text', value: `▶ ${label}` }]);
+        }
+        parent.children[index] = replacement;
+        return [SKIP, index];
+      }
+
+      if (node.tagName === 'audio') {
+        const label = stringProp(node, 'ariaLabel', 'aria-label', 'title') || 'Listen';
+        const href = absolutize(preferredSource(node, /mpe?g|mp3/i), siteUrl);
+        parent.children[index] = link(href || '#', [{ type: 'text', value: `🔊 ${label}` }]);
+        return [SKIP, index];
+      }
+    });
+  };
+}


### PR DESCRIPTION
## Problem

The [gif-or-jif audiobook post](https://ben.balter.com/2026/09/08/gif-or-jif-audiobook-both-ways/) is the first post with raw `<style>`, `<video>`, and `<audio>` in its body. The email broadcast passed those straight into the Kit v4 payload, and Kit rejected the whole broadcast at send with a generic `422 ("There has been an error saving your changes")`, retried four times, and failed. ([failing run](https://github.com/benbalter/benbalter.github.com/actions/runs/34165036924/job/101874300496))

The cause is isolated, not just inferred: every prior post has **0** media tags and sent fine, and a same-era post with a **292-char** description sent fine too, so payload shape and preview-text length are ruled out. Media tags (11 vs 0) are the lone anomaly, and they're broken in an inbox regardless (clients strip `<style>`, don't play inline `<video>`/`<audio>`, and the asset URLs were root-relative).

## Fix

Add `rehypeEmailMediaFallback`, a rehype plugin that runs in the email pipeline only (after `rehypeRaw`):

- drops `<style>` blocks
- replaces `<video>` with its poster `<img>` linking to the mp4 (or a "▶ label" link when there's no poster)
- replaces `<audio>` with a "🔊 label" link to the mp3
- absolutizes all asset URLs against `SITE_URL` (the email pipeline deliberately omits relative-URL rewriting)

Web rendering is untouched. Adds unit tests covering each transform.

## Verification

- 7 new unit tests pass (`vitest run src/lib/rehype-email-media-fallback.test.ts`)
- `npm run check` clean
- Full re-render of the actual post confirms zero `<style>/<video>/<audio>/<source>` tags and no relative asset URLs remain in the email HTML

## Follow-up (not in this PR)

After merge, re-send the broadcast via `workflow_dispatch` with `post_path` set to the gif-or-jif post (an irreversible send to all subscribers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)